### PR TITLE
Fix for scene getSelectedNodes

### DIFF
--- a/openHarmony/openHarmony_node.js
+++ b/openHarmony/openHarmony_node.js
@@ -658,7 +658,7 @@ Object.defineProperty($.oNode.prototype, 'linkedColumns', {
  * @return  {int}    The index within that timeline.
  */
  $.oNode.prototype.timelineIndex = function(timeline){
-    var _timeline = timeline.layersList;
+    var _timeline = timeline.layers;
     return _timeline.indexOf(this.path);
 }
  


### PR DESCRIPTION
`$.scn.getSelectedNodes` was breaking because `oNode` was referring to a non-existent function `oTimeline.layersList`, this fixes that.