### PR TITLE
Fix groupPath in $.oGroupNode.prototype.addBackdrop

### DIFF
--- a/openHarmony/openHarmony_node.js
+++ b/openHarmony/openHarmony_node.js
@@ -2451,9 +2451,8 @@ $.oGroupNode.prototype.addBackdrop = function(title, body, color, x, y, width, h
 
   var position = {"x":x, "y":y, "w":width, "h":height};
 
-  if (typeof groupPath === 'undefined') var groupPath = "Top";
-
-  if(groupPath instanceof this.$.oGroupNode) groupPath = groupPath.path;
+  var groupPath = this.path;
+  
   if(!(color instanceof this.$.oColorValue)) color = new this.$.oColorValue(color);
 
 


### PR DESCRIPTION
Backdrops created from a group node in `$.oGroupNode.prototype.addBackdrop()` are being pathed to the scene root ("Top").
In this method, since the `groupPath` parameter is not passed, but we are in the instance of the `$.oGroupNode` object, we simply need to declare the `groupPath` as `this.path`.