### PR TITLE
Args in wrong order for addColumn()

### DIFF
--- a/openHarmony/openHarmony_node.js
+++ b/openHarmony/openHarmony_node.js
@@ -3018,8 +3018,8 @@ $.oGroupNode.prototype.importPSD = function( path, separateLayers, addPeg, addCo
   var _ySpacing = 30;
 
   var _element = this.scene.addElement(_elementName, "PSD");
-  var _column = this.scene.addColumn(_elementName, "DRAWING", _element);
-
+  var _column = this.scene.addColumn("DRAWING", _elementName, _element); // TYPE and NAME were switched around. The definition is addColumnn( type, name, oElementObject )
+		
   // save scene otherwise PSD is copied correctly into the element
   // but the TGA for each layer are not generated
   // TODO: how to go around this to avoid saving?


### PR DESCRIPTION
PSD import failed with a type error, because we were supplying "DRAWING" as the column name, and _elementName as the type. I fixed it by switching them around here, but it makes it inconsistent with addElement() so maybe it would be better to update the func definition?