### PR TITLE
Fix scene.length setter for shorter lengths

### DIFF
--- a/openHarmony/openHarmony_scene.js
+++ b/openHarmony/openHarmony_scene.js
@@ -600,9 +600,9 @@ Object.defineProperty($.oScene.prototype, 'length', {
         var _length = frame.numberOf();
         var _toAdd = newLength-_length;
         if (_toAdd>0){
-            frame.insert(_length-1, _toAdd)
+            frame.insert(_length, _toAdd)
         }else{
-            frame.remove(_length-1, _toAdd)
+            frame.remove(_length-_toAdd, -_toAdd)
         }
     }
 });


### PR DESCRIPTION
Setting a scene's length to shorter than the current length produced no result when I tested it in H20. I think it's because `frame.remove()` expects a positive value for the number of frames to remove.
I rearranged it so that it starts countign frames to remove at `scene.length - difference`, then removed `difference` frames.
I also removed the -1 offset present in the original. Not sure what it was doing, but maybe I don't realise the importance. If we used `ripple_markers` or `extend_exposures` maybe it would do something?