### PR TITLE
Get oScene.renderWriteNodes Linux compatible

### DIFF
--- a/openHarmony/openHarmony_scene.js
+++ b/openHarmony/openHarmony_scene.js
@@ -2170,7 +2170,7 @@ $.oScene.prototype.renderWriteNodes = function(renderInBackground, startFrame, e
   if (typeof resY === 'undefined') var resY = this.resolutionY;
 
   this.save();
-  var harmonyBin = specialFolders.bin+"/HarmonyPremium.exe";
+  var harmonyBin = specialFolders.bin+"/HarmonyPremium";
 
   var args = ["-batch", "-frames", startFrame, endFrame, "-res", resX, resY, this.fov];
 

--- a/openHarmony/openHarmony_threading.js
+++ b/openHarmony/openHarmony_threading.js
@@ -534,9 +534,9 @@ $.oProcess.prototype.launchAndRead = function(readCallback, finishedCallback){
   if (about.isLinuxArch()) {
     p.start(this.bin, this.queryArgs);
   } else {
-    var directory = bin.join("/");
     var bin = this.bin.split("/");
     var app = bin.pop();
+    var directory = bin.join("/");
     p.setWorkingDirectory(directory);
     p.start(app, this.queryArgs);
   }

--- a/openHarmony/openHarmony_threading.js
+++ b/openHarmony/openHarmony_threading.js
@@ -510,12 +510,7 @@ $.oProcess.prototype.terminate = function(){
 $.oProcess.prototype.launchAndRead = function(readCallback, finishedCallback){
   if (typeof timeOut === 'undefined') var timeOut = -1;
 
-  var bin = this.bin.split("/");
-	var app = bin.pop();
-	var directory = bin.join("\\");
-
   var p = this.process;
-	p.setWorkingDirectory(directory);
 
   this.$.debug("Executing Process with arguments : "+this.bin+" "+this.queryArgs.join(" "), this.$.DEBUG_LEVEL.LOG);
 
@@ -536,7 +531,15 @@ $.oProcess.prototype.launchAndRead = function(readCallback, finishedCallback){
   if (typeof readCallback !== 'undefined') this.readyRead.connect(readCallback);
   if (typeof finishedCallback !== 'undefined') this.finished.connect(onFinished);
 
-  p.start(app, this.queryArgs);
+  if (about.isLinuxArch()) {
+    p.start(this.bin, this.queryArgs);
+  } else {
+    var directory = bin.join("/");
+    var bin = this.bin.split("/");
+    var app = bin.pop();
+    p.setWorkingDirectory(directory);
+    p.start(app, this.queryArgs);
+  }
 }
 
 


### PR DESCRIPTION
Currently, `oScene.renderWriteNodes()` doesn't work on Linux.
This fix the compatibility.