### PR TITLE
Fix object calls and add parameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 node_modules/*
-
+.vscode

--- a/openHarmony/openHarmony_drawing.js
+++ b/openHarmony/openHarmony_drawing.js
@@ -446,7 +446,7 @@ $.oDrawing.prototype.importBitmap = function (file, convertToTvg) {
     var _convertedFilePath = tempFolder.path + "/" + file.name + ".tvg";
     var _convertProcess = new this.$.oProcess(_bin, ["-outformat", "TVG", "-debug", "-resolution", res_x, res_y, "-outfile", _convertedFilePath, file.path]);
     log(_convertProcess.execute())
- 
+
     var convertedFile = new this.$.oFile(_convertedFilePath);
     if (!convertedFile.exists) throw new Error ("Converting " + file.path + " to TVG has failed.");
 
@@ -590,7 +590,7 @@ $.oDrawing.prototype.copyContents = function (artLayer) {
 
   var _current = this.setAsActiveDrawing(artLayer);
   if (!_current) {
-    this.$.debug("Impossible to copy contents of drawing " + this.name + " of element " + _element.name + ", the drawing cannot be set as active.", this.DEBUG_LEVEL.ERROR);
+    this.$.debug("Impossible to copy contents of drawing " + this.name + " of element " + _element.name + ", the drawing cannot be set as active.", this.$.DEBUG_LEVEL.ERROR);
     return;
   }
   ToolProperties.setApplyAllArts(!artLayer);
@@ -610,7 +610,7 @@ $.oDrawing.prototype.pasteContents = function (artLayer) {
 
   var _current = this.setAsActiveDrawing(artLayer);
   if (!_current) {
-    this.$.debug("Impossible to copy contents of drawing " + this.name + " of element " + _element.name + ", the drawing cannot be set as active.", this.DEBUG_LEVEL.ERROR);
+    this.$.debug("Impossible to copy contents of drawing " + this.name + " of element " + _element.name + ", the drawing cannot be set as active.", this.$.DEBUG_LEVEL.ERROR);
     return;
   }
   ToolProperties.setApplyAllArts(!artLayer);
@@ -629,13 +629,13 @@ $.oDrawing.prototype.pasteContents = function (artLayer) {
 */
 $.oDrawing.prototype.setLineEnds = function (endType, artLayer) {
   if (this.$.batchMode) {
-    this.$.debug("setting line ends not available in batch mode", this.DEBUG_LEVEL.ERROR);
+    this.$.debug("setting line ends not available in batch mode", this.$.DEBUG_LEVEL.ERROR);
     return;
   }
 
   var _current = this.setAsActiveDrawing(artLayer);
   if (!_current) {
-    this.$.debug("Impossible to change line ends on drawing " + this.name + " of element " + _element.name + ", the drawing cannot be set as active.", this.DEBUG_LEVEL.ERROR);
+    this.$.debug("Impossible to change line ends on drawing " + this.name + " of element " + _element.name + ", the drawing cannot be set as active.", this.$.DEBUG_LEVEL.ERROR);
     return;
   }
 

--- a/openHarmony/openHarmony_element.js
+++ b/openHarmony/openHarmony_element.js
@@ -292,7 +292,7 @@ $.oElement.prototype.duplicate = function(name){
       var duplicateDrawing = _duplicateElement.addDrawing(0, _drawings[i].name, _drawingFile);
       _drawingFile.copy(_elementFolder, duplicateDrawing.name, true);
     }catch(err){
-      this.debug("could not copy drawing file "+drawingFile.name+" into element "+_duplicateElement.name, this.DEBUG_LEVEL.ERROR);
+      this.debug("could not copy drawing file "+_drawingFile.name+" into element "+_duplicateElement.name, this.$.DEBUG_LEVEL.ERROR);
     }
   }
   return _duplicateElement;

--- a/openHarmony/openHarmony_file.js
+++ b/openHarmony/openHarmony_file.js
@@ -251,7 +251,7 @@ $.oFolder.prototype.listEntries = function(contentType, filter) {
 
   var _dir = new QDir(this.path);
   if (!_dir.exists()){
-    this.$.debug("can't get files from folder "+path+" because it doesn't exist", this.$.DEBUG_LEVEL.ERROR);
+    this.$.debug("can't get files from folder "+this.path+" because it doesn't exist", this.$.DEBUG_LEVEL.ERROR);
     return [];
   }
 
@@ -394,7 +394,7 @@ $.oFolder.prototype.move = function( destFolderPath, overwrite ){
         throw new Error("destination file "+dir.path+" exists and will not be overwritten. Can't move folder.");
 
     var path = fileMapper.toNativePath(this.path);
-    var destPath = fileMapper.toNativePath(dir.path+"/");
+    var destPath = fileMapper.toNativePath(dir.path);
 
     var destDir = new Dir;
     try {
@@ -643,7 +643,7 @@ $.oFile.prototype.read = function() {
       return string;
     }
   } catch (err) {
-    this.$.debug(err, this.DEBUG_LEVEL.ERROR)
+    this.$.debug(err, this.$.DEBUG_LEVEL.ERROR)
     return null
   }
 }
@@ -762,7 +762,7 @@ $.oFile.prototype.copy = function( destfolder, copyName, overwrite){
     var _dest = new PermanentFile(destfolder+"/"+_fileName);
 
     if (_dest.exists() && !overwrite){
-        throw new Error("Destination file "+destfolder+"/"+_fileName+" exists and will not be overwritten. Can't copy file.", this.DEBUG_LEVEL.ERROR);
+        throw new Error("Destination file "+destfolder+"/"+_fileName+" exists and will not be overwritten. Can't copy file.", this.$.DEBUG_LEVEL.ERROR);
     }
 
     this.$.debug("copying "+_file.path()+" to "+_dest.path(), this.$.DEBUG_LEVEL.LOG)

--- a/openHarmony/openHarmony_scene.js
+++ b/openHarmony/openHarmony_scene.js
@@ -301,7 +301,7 @@ Object.defineProperty($.oScene.prototype, 'aspectRatioY', {
         return scene.unitsAspectRatioY();
     },
     set : function(val){
-        scene.setUnitsAspectRatio( this.aspectRatioY, val );
+        scene.setUnitsAspectRatio( this.aspectRatioX, val );
     }
 });
 
@@ -2065,23 +2065,25 @@ $.oScene.prototype.updatePSD = function( path, group, separateLayers ){
  * @param   {double}         scale                         The scale of the export compared to the scene resolution.
  * @param   {bool}           exportSound                   Whether to include the sound in the export.
  * @param   {bool}           exportPreviewArea             Whether to only export the preview area of the timeline.
- *
- * @return {bool}        The success of the export
- */
-$.oScene.prototype.exportQT = function( path, display, scale, exportSound, exportPreviewArea){
+ * @param   {bool}           createThumbnail               Whether to create a thumbnail at the first frame.
+*
+* @return {bool}        The success of the export
+*/
+$.oScene.prototype.exportQT = function (path, display, scale, exportSound, exportPreviewArea, createThumbnail){
   if (typeof display === 'undefined') var display = node.getName(node.getNodes(["DISPLAY"])[0]);
   if (typeof exportSound === 'undefined') var exportSound = true;
   if (typeof exportPreviewArea === 'undefined') var exportPreviewArea = false;
   if (typeof scale === 'undefined') var scale = 1;
+  if (typeof createThumbnail === 'undefined') var createThumbnail = true;
 
   if (display instanceof oNode) display = display.name;
 
   var _startFrame = exportPreviewArea?scene.getStartFrame():1;
-  var _stopFrame = exportPreviewArea?scene.getStopFrame():this.length-1;
-  var _resX = this.defaultResolutionX*scale
-  var _resY= this.defaultResolutionY*scale
-  return exporter.exportToQuicktime ("", _startFrame, _stopFrame, exportSound, _resX, _resY, path, display, true, 1);
-}
+  var _stopFrame = exportPreviewArea?scene.getStopFrame():this.length;
+  var _resX = this.defaultResolutionX*scale;
+  var _resY= this.defaultResolutionY*scale;
+  return exporter.exportToQuicktime("", _startFrame, _stopFrame, exportSound, _resX, _resY, path, display, createThumbnail, 1);
+};
 
 
 /**


### PR DESCRIPTION
Hello, I've noticed three things :

- some log constant calls miss the `$` : [exemple](https://github.com/cfourney/OpenHarmony/compare/master...dragonbleapiece:OpenHarmony:fix-object-calls-and-add-parameter?expand=1#diff-d6d1095fe1765d92cd1e402448b526a8b3e6f466d5aa98e394d7f2071127d75cL632)
- some refactor or copy typos : [parameter doesn't exist](https://github.com/cfourney/OpenHarmony/compare/master...dragonbleapiece:OpenHarmony:fix-object-calls-and-add-parameter?expand=1#diff-28f4197517d9ed597c13b13733084b0bbf62111cf495507440481fcf08ff921eL295) and [copy paste symptoms](https://github.com/cfourney/OpenHarmony/compare/master...dragonbleapiece:OpenHarmony:fix-object-calls-and-add-parameter?expand=1#diff-b838e76c15b365ce3f16e51cbbf17b23d8c65da20e7b98c5335a514b5f470d19L304)
- I removed the slash [here](https://github.com/cfourney/OpenHarmony/compare/master...dragonbleapiece:OpenHarmony:fix-object-calls-and-add-parameter?expand=1#diff-ddb58dd5b6e27caf1ba49fca49d8017a73a6e26067994152d532ba3cd9ed0b29L397). I don't understand why it should be here. I encountered an error due to that. I encountered the error two months ago and I didn't think to copy paste it somewhere.

And I changed a method signature :

- I added an optional parameter to exportQT : [here](https://github.com/cfourney/OpenHarmony/compare/master...dragonbleapiece:OpenHarmony:fix-object-calls-and-add-parameter?expand=1#diff-b838e76c15b365ce3f16e51cbbf17b23d8c65da20e7b98c5335a514b5f470d19R2072)

Have a nice day !