### PR TITLE
Add tvg support for video import

### DIFF
--- a/openHarmony/openHarmony_node.js
+++ b/openHarmony/openHarmony_node.js
@@ -3712,14 +3712,16 @@ $.oGroupNode.prototype.importImageSequence = function(imagePaths, exposureLength
  * @param   {bool}           [extendScene=true]            Whether to extend the scene to the duration of the QT.
  * @param   {string}         [alignment="ASIS"]            Alignment type.
  * @param   {$.oPoint}       [nodePosition]                The position for the node to be placed in the network.
+ * @param {bool}             [convertToTvg=false]          Convert movie frames to TVG format.
  *
  * @return {$.oNode}        The imported Quicktime Node.
  */
-$.oGroupNode.prototype.importQT = function( path, importSound, extendScene, alignment, nodePosition){
+$.oGroupNode.prototype.importQT = function( path, importSound, extendScene, alignment, nodePosition, convertToTvg){
   if (typeof alignment === 'undefined') var alignment = "ASIS";
   if (typeof extendScene === 'undefined') var extendScene = true;
   if (typeof importSound === 'undefined') var importSound = true;
   if (typeof nodePosition === 'undefined') var nodePosition = new this.$.oPoint(0,0,0);
+  if (typeof convertToTvg === 'undefined') var convertToTvg = false;
 
   var _QTFile = (path instanceof this.$.oFile)?path:new this.$.oFile(path);
   if (!_QTFile.exists){
@@ -3729,7 +3731,11 @@ $.oGroupNode.prototype.importQT = function( path, importSound, extendScene, alig
   var _movieName = _QTFile.name;
   this.$.beginUndo("oH_importQT_"+_movieName);
 
-  var _element = this.scene.addElement(_movieName, "PNG");
+  var imageFormat = "PNG"
+  if (convertToTvg) {
+    imageFormat = "TVG"
+  }
+  var _element = this.scene.addElement(_movieName, imageFormat);
   var _elementName = _element.name;
 
   var _movieNode = this.addDrawingNode(_movieName, nodePosition, _element);
@@ -3755,7 +3761,7 @@ $.oGroupNode.prototype.importQT = function( path, importSound, extendScene, alig
   MovieImport.setImageFolder(_tempFolder);
   MovieImport.setImagePrefix(_movieName);
   if (importSound) MovieImport.setAudioFile(_audioPath);
-  this.$.log("converting movie file to pngs...");
+  this.$.log("converting movie file to images...");
   MovieImport.doImport();
   this.$.log("conversion finished");
 
@@ -3769,7 +3775,7 @@ $.oGroupNode.prototype.importQT = function( path, importSound, extendScene, alig
   // create a drawing for each frame
   for (var i=1; i<=_movielength; i++) {
     _drawingPath = _tempFolder + "/" + _movieName + "-" + i + ".png";
-    _element.addDrawing(i, i, _drawingPath);
+    _element.addDrawing(i, i, _drawingPath, convertToTvg);
   }
 
   progressDialog.value = 95;

--- a/openHarmony/openHarmony_scene.js
+++ b/openHarmony/openHarmony_scene.js
@@ -2091,19 +2091,21 @@ $.oScene.prototype.exportQT = function (path, display, scale, exportSound, expor
  * @Deprecated
  * @param   {string}         path                          The quicktime file to import.
  * @param   {string}         group                         The group to import the QT into.
+ * @param   {bool}           importSound                   Whether to import the sound
  * @param   {$.oPoint}       nodePosition                  The position for the node to be placed in the network.
  * @param   {bool}           extendScene                   Whether to extend the scene to the duration of the QT.
  * @param   {string}         alignment                     Alignment type.
+ * @param   {bool}           convertToTvg                  Convert movie frames to TVG format.
  *
  * @return {$.oNode}        The imported Quicktime Node.
  */
-$.oScene.prototype.importQT = function( path, group, importSound, nodePosition, extendScene, alignment ){
+$.oScene.prototype.importQT = function( path, group, importSound, nodePosition, extendScene, alignment, convertToTvg ){
   if (typeof group === 'undefined') var group = this.root;
   var _group = (group instanceof this.$.oGroupNode)?group:this.$node(group);
 
   if (_group != null && _group instanceof this.$.oGroupNode){
     this.$.log("oScene.importQT is deprecated. Use oGroupNode.importQTs instead")
-    var _node = _group.importQT(path, importSound, extendScene, alignment, nodePosition)
+    var _node = _group.importQT(path, importSound, extendScene, alignment, nodePosition, convertToTvg)
     return _node;
   }else{
     throw new Error (group+" is an invalid group to import a QT file to.")


### PR DESCRIPTION
Add support for tvg image conversion in video import 

Before, the image sequence format behind every video import was necessarily png

With these changes, we can now choose to convert the images to tvg

I'm not an openHarmony expert, so please let me know if you detect any error/misunderstanding
Thanks for your great work !