### PR TITLE
fix: minor fixes 4 quaternions in attribute file

### DIFF
--- a/openHarmony/openHarmony_attribute.js
+++ b/openHarmony/openHarmony_attribute.js
@@ -688,11 +688,11 @@ $.oAttribute.prototype.addColumn = function(){
       break;
 
     case "QUATERNION_PATH" :
-      _columnName = "QUARTERNION";
+      _columnType = "QUARTERNION";
       break;
 
       case "PATH_3D" :
-      _columnName = "3DPATH";
+      _columnType = "3DPATH";
       break;
 
     case "ELEMENT" :

--- a/openHarmony/openHarmony_attribute.js
+++ b/openHarmony/openHarmony_attribute.js
@@ -687,7 +687,7 @@ $.oAttribute.prototype.addColumn = function(){
       _columnType = "BEZIER";
       break;
 
-    case "QUATERNIONPATH" :
+    case "QUATERNION_PATH" :
       _columnName = "QUARTERNION";
       break;
 

--- a/openHarmony/openHarmony_attribute.js
+++ b/openHarmony/openHarmony_attribute.js
@@ -623,10 +623,10 @@ $.oAttribute.prototype.setValue = function (value, frame) {
 
         case "PATH_3D" :
           // check if frame is tied to a column or an attribute
-          var _frame = _column?(new this.$.oFrame(frame, this.column)):(new this.$.oFrame(frame, _attr));
+          var _frame = _column?(new this.$.oFrame(frame, _column)):(new this.$.oFrame(frame, _attr));
           if (_column){
             if (!_frame.isKeyframe) _frame.isKeyframe = true;
-            var _point = new this.$.oPathPoint (this.column, _frame);
+            var _point = new this.$.oPathPoint (_column, _frame);
             _point.set(value);
           }else{
             // TODO: create keyframe?

--- a/openHarmony/openHarmony_attribute.js
+++ b/openHarmony/openHarmony_attribute.js
@@ -688,7 +688,7 @@ $.oAttribute.prototype.addColumn = function(){
       break;
 
     case "QUATERNION_PATH" :
-      _columnType = "QUARTERNION";
+      _columnType = "QUATERNIONPATH";
       break;
 
       case "PATH_3D" :


### PR DESCRIPTION
Fix four different minor problems in `openHarmony_attributes.js` (see the 4 different commits) :

- In the `setValue` function, for a value of type PATH3D, the code refered to the current column with `this.column`. However, if `this.column` doesn't exist, it's created earlier and stored in the `_column` variable. So it's this `_column` that should be used by the function
- In the `addColumn` function, when the current type was quaternion or 3D path, it was the column name which was set instead of the column type
- In the `addColumn` function, the current type for quaternion is called `QUATERNIONPATH` when it should be called `QUATERNION_PATH`
- In the `addColumn` function, the column type is set to `QUARTERNION`, when it should be set to `QUATERNIONPATH`

Regarding that last fix, I noted some inconsistent behaviour in Harmony. This piece of code works

```
var test = column.add("myColumnName", "QUATERNIONPATH");
```
But this doesn't :
```
var test = column.add("myColumnName", "QUATERNION"); //Fails
```
Which is weird because in the doc the correct type string is supposed to be `QUATERNION`
![image](https://user-images.githubusercontent.com/32680314/233015885-95dba0fd-6680-457c-a183-6a08625e1cbf.png)

But it does not work in practice, and it's this incoherence that motivates that last commit/fix. If I have missed something about Harmony behavior, please let me know
