### PR TITLE
Require refactor

### DIFF
--- a/examples/openHarmonyExample.js
+++ b/examples/openHarmonyExample.js
@@ -1,5 +1,5 @@
 // add this line at the top of your scripts to load the library before the execution.
-include("openHarmony.js")
+const $ = require("openHarmony.js");
 
 
 /**

--- a/openHarmony.js
+++ b/openHarmony.js
@@ -157,7 +157,7 @@ for (var i in _files){
 
   for (var _key in _exported) {
     if (_exported.hasOwnProperty(_key)) {           
-        MessageLog.trace("$." + _key + " = " + _files[i] + ":" + _key);
+        // MessageLog.trace("$." + _key + " = " + _files[i] + ":" + _key);
 
         $[_key] = _exported[_key];
         

--- a/openHarmony.js
+++ b/openHarmony.js
@@ -72,7 +72,7 @@
  * @example
  * // To access the functions, first call the $ object. It is made available after loading openHarmony like so:
  *
- * include ("openHarmony.js");
+ * const $ = require ("openHarmony.js");
  *
  * var doc = $.scn;                    // grabbing the scene document
  * $.log("hello");                     // prints out a message to the MessageLog.
@@ -86,18 +86,19 @@
  *
  */
 $ = {
-  debug_level : 0,
-
- /**
- * Enum to set the debug level of debug statements.
- * @name    $#DEBUG_LEVEL
- * @enum
- */
-  DEBUG_LEVEL : {
-                 'ERROR'   : 0,
-                 'WARNING' : 1,
-                 'LOG'     : 2
-                },
+  debug_level: 0,
+  /**
+   * Enum to set the debug level of debug statements.
+   * @name    $#DEBUG_LEVEL
+   * @enum
+   */
+  DEBUG_LEVEL: {
+    "ERROR": 0,
+    "WARNING": 1,
+    "LOG": 2,
+    "INFO": 2,
+    "DEBUG": 3
+  },
   file      : __file__,
   directory : false,
   pi        : 3.14159265359
@@ -148,10 +149,28 @@ _dir.setFilter( QDir.Files);
 var _files = _dir.entryList();
 
 for (var i in _files){
-  include( _ohDirectory + "/" + _files[i]);
+  const _path = "openHarmony/" + _files[i];
+  try {
+    const _exported = require(_path);
+  } catch (e) {
+    MessageLog.trace("Error requiring " + _path + ": " + e);
+  }
+
+  for (var _key in _exported) {
+    if (_exported.hasOwnProperty(_key)) {           
+        MessageLog.trace("$." + _key + " = " + _files[i] + ":" + _key);
+
+        $[_key] = _exported[_key];
+        
+        /* Tried this instead of $[_key] = _exported[_key] to transfer properties
+        with setters and getters defined on a script's exports object, but they
+        are skipped? It's ok because oH doesn't use anything like this 
+        Object.defineProperty(
+          $, _key, Object.getOwnPropertyDescriptor(_exported, _key));
+        */
+    }
+  }
 }
-
-
 
 
 /**
@@ -529,5 +548,8 @@ for( var classItem in $ ){
 }
 
 
-// Add global access to $ object
-this.__proto__.$ = $
+// Doesn't work
+// // Add global access to $ object
+// this.__proto__.$ = $
+
+exports = $

--- a/openHarmony.js
+++ b/openHarmony.js
@@ -547,8 +547,7 @@ for( var classItem in $ ){
 }
 
 
-// Doesn't work
-// // Add global access to $ object
-// this.__proto__.$ = $
+// Add global access to $ object
+this.__proto__.$ = $
 
 exports = $

--- a/openHarmony.js
+++ b/openHarmony.js
@@ -543,6 +543,12 @@ for( var classItem in $ ){
 
     //Also extend it to the global object.
     this[classItem] = $[classItem];
+
+    /*
+      This didn't do what I expected, but after require()ing oH in, all the functions
+      are properties of the top-level this.
+    */
+    // this.__proto__[classItem] = $[classItem];
   }
 }
 

--- a/openHarmony.js
+++ b/openHarmony.js
@@ -112,8 +112,7 @@ $ = {
  */
 Object.defineProperty( $, "directory", {
   get : function(){
-    var currentFile = __file__
-    return currentFile.split("\\").join("/").split( "/" ).slice(0, -1).join('/');
+    return $.file.split("\\").join("/").split( "/" ).slice(0, -1).join('/');
   }
 });
 

--- a/openHarmony/openHarmony_application.js
+++ b/openHarmony/openHarmony_application.js
@@ -38,7 +38,6 @@
 //////////////////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////////////
 
-
 //////////////////////////////////////
 //////////////////////////////////////
 //                                  //
@@ -55,7 +54,7 @@
  * The $.oApp class provides access to the Harmony application and its widgets.
  * @constructor
  */
-$.oApp = function(){
+exports.oApp = function(){
 }
 
 
@@ -65,7 +64,7 @@ $.oApp = function(){
  * @type {string}
  * @readonly
  */
- Object.defineProperty($.oApp.prototype, 'versionString', {
+ Object.defineProperty(exports.oApp.prototype, 'versionString', {
   get : function(){
     return about.getVersionInfoStr().split("version").pop().split("build")[0].replace(/\s/g, "");
   }
@@ -78,7 +77,7 @@ $.oApp = function(){
  * @type {int}
  * @readonly
  */
-Object.defineProperty($.oApp.prototype, 'version', {
+Object.defineProperty(exports.oApp.prototype, 'version', {
   get : function(){
     return parseInt(this.versionString.split(".")[0], 10);
   }
@@ -91,7 +90,7 @@ Object.defineProperty($.oApp.prototype, 'version', {
  * @type {int}
  * @readonly
  */
-Object.defineProperty($.oApp.prototype, 'minorVersion', {
+Object.defineProperty(exports.oApp.prototype, 'minorVersion', {
   get : function(){
     return parseInt(this.versionString.split(".")[1], 10);
   }
@@ -103,7 +102,7 @@ Object.defineProperty($.oApp.prototype, 'minorVersion', {
  * @type {int}
  * @readonly
  */
- Object.defineProperty($.oApp.prototype, 'patch', {
+ Object.defineProperty(exports.oApp.prototype, 'patch', {
   get : function(){
     return parseInt(this.versionString.split(".")[2], 10);
   }
@@ -117,7 +116,7 @@ Object.defineProperty($.oApp.prototype, 'minorVersion', {
  * @type {string}
  * @readonly
  */
-Object.defineProperty($.oApp.prototype, 'flavour', {
+Object.defineProperty(exports.oApp.prototype, 'flavour', {
   get : function(){
     return about.getFlavorString();
   }
@@ -130,7 +129,7 @@ Object.defineProperty($.oApp.prototype, 'flavour', {
  * @type {QWidget}
  * @readonly
  */
-Object.defineProperty($.oApp.prototype, 'mainWindow', {
+Object.defineProperty(exports.oApp.prototype, 'mainWindow', {
   get : function(){
     var windows = QApplication.topLevelWidgets();
     for ( var i in windows) {
@@ -147,7 +146,7 @@ Object.defineProperty($.oApp.prototype, 'mainWindow', {
  * @type {QToolbar}
  * @readonly
  */
-Object.defineProperty($.oApp.prototype, 'toolbars', {
+Object.defineProperty(exports.oApp.prototype, 'toolbars', {
   get : function(){
     var widgets = QApplication.allWidgets();
     var _toolbars = widgets.filter(function(x){return x instanceof QToolBar})
@@ -157,16 +156,15 @@ Object.defineProperty($.oApp.prototype, 'toolbars', {
 });
 
 
-
 /**
  * The Position of the mouse cursor in the toonboom window coordinates.
  * @name $.oApp#mousePosition
  * @type {$.oPoint}
  * @readonly
  */
-Object.defineProperty($.oApp.prototype, 'mousePosition', {
+Object.defineProperty(exports.oApp.prototype, 'mousePosition', {
   get : function(){
-    var _position = this.$.app.mainWindow.mapFromGlobal(QCursor.pos());
+    var _position = this.mainWindow.mapFromGlobal(QCursor.pos());
     return new this.$.oPoint(_position.x(), _position.y(), 0);
   }
 });
@@ -178,7 +176,7 @@ Object.defineProperty($.oApp.prototype, 'mousePosition', {
  * @type {$.oPoint}
  * @readonly
  */
-Object.defineProperty($.oApp.prototype, 'globalMousePosition', {
+Object.defineProperty(exports.oApp.prototype, 'globalMousePosition', {
   get : function(){
     var _position = QCursor.pos();
     return new this.$.oPoint(_position.x(), _position.y(), 0);
@@ -211,7 +209,7 @@ Object.defineProperty($.oApp.prototype, 'globalMousePosition', {
  *
  * brushTool.activate()           // by using the activate function of the oTool class
  */
-Object.defineProperty($.oApp.prototype, 'tools', {
+Object.defineProperty(exports.oApp.prototype, 'tools', {
   get: function(){
     if (typeof this._toolsObject === 'undefined'){
       this._toolsObject = [];
@@ -236,13 +234,13 @@ Object.defineProperty($.oApp.prototype, 'tools', {
  * @name $.oApp#currentTool
  * @type {$.oTool}
  */
-Object.defineProperty($.oApp.prototype, 'currentTool', {
+Object.defineProperty(exports.oApp.prototype, 'currentTool', {
   get : function(){
     var _tool = Tools.getToolSettings().currentTool.id;
     return _tool;
   },
   set : function(tool){
-    if (tool instanceof this.$.oTool) {
+    if (tool instanceof oTool) {
       tool.activate();
       return
     }
@@ -251,7 +249,7 @@ Object.defineProperty($.oApp.prototype, 'currentTool', {
         this.getToolByName(tool).activate();
         return
       }catch(err){
-        this.$.debug("'"+ tool + "' is not a valid tool name. Valid: "+this.tools.map(function(x){return x.name}).join(", "))
+        log.debug("'"+ tool + "' is not a valid tool name. Valid: "+this.tools.map(function(x){return x.name}).join(", "))
       }
     }
     if (typeof tool == "number"){
@@ -268,7 +266,7 @@ Object.defineProperty($.oApp.prototype, 'currentTool', {
  * @param   {string}   [parentName]      The name of the parent widget to look into, in case of duplicates.
  * @return  {QWidget}   The widget if found, or null if it doesn't exist.
  */
-$.oApp.prototype.getWidgetByName = function(name, parentName){
+exports.oApp.prototype.getWidgetByName = function(name, parentName){
   var widgets = QApplication.allWidgets();
   for( var i in widgets){
     if (widgets[i].objectName == name){
@@ -307,7 +305,7 @@ $.oApp.prototype.getWidgetByName = function(name, parentName){
  * // the preference object also holds a categories array with the list of all categories
  * log (prefs.categories)
  */
-Object.defineProperty($.oApp.prototype, 'preferences', {
+Object.defineProperty(exports.oApp.prototype, 'preferences', {
   get: function(){
     if (typeof this._prefsObject === 'undefined'){
       var _prefsObject = {};
@@ -324,11 +322,11 @@ Object.defineProperty($.oApp.prototype, 'preferences', {
         value:_details
       })
 
-      var prefFile = (new oFile(specialFolders.resource+"/prefs.xml")).parseAsXml().children[0].children;
+      var prefFile = (new this.$.oFile(specialFolders.resource+"/prefs.xml")).parseAsXml().children[0].children;
 
-      var userPrefFile = new oFile(specialFolders.userConfig + "/Harmony Premium-pref.xml")
+      var userPrefFile = new this.$.oFile(specialFolders.userConfig + "/Harmony Premium-pref.xml")
       // Harmony Pref file is called differently on the database userConfig
-      if (!userPrefFile.exists) userPrefFile = new oFile(specialFolders.userConfig + "/Harmony-pref.xml")
+      if (!userPrefFile.exists) userPrefFile = new this.$.oFile(specialFolders.userConfig + "/Harmony-pref.xml")
 
       if (userPrefFile.exists){
         var userPref = {objectName: "category", id: "user", children:userPrefFile.parseAsXml().children[0].children};
@@ -394,11 +392,11 @@ Object.defineProperty($.oApp.prototype, 'preferences', {
  *   }
  * }
  */
-Object.defineProperty($.oApp.prototype, 'stencils', {
+Object.defineProperty(exports.oApp.prototype, 'stencils', {
   get: function(){
     if (typeof this._stencilsObject === 'undefined'){
       // parse stencil xml file penstyles.xml to get stencils info
-      var stencilsFile = (new oFile(specialFolders.userConfig+"/penstyles.xml")).read();
+      var stencilsFile = (new this.$.oFile(specialFolders.userConfig+"/penstyles.xml")).read();
       var penRegex = /<pen>([\S\s]*?)<\/pen>/igm
       var stencils = [];
       var stencilXml;
@@ -419,13 +417,13 @@ Object.defineProperty($.oApp.prototype, 'stencils', {
  * @name $.oApp#currentStencil
  * @type {$.oStencil}
  */
-Object.defineProperty($.oApp.prototype, 'currentStencil', {
+Object.defineProperty(exports.oApp.prototype, 'currentStencil', {
   get: function(){
     return this.stencils[PaletteManager.getCurrentPenstyleIndex()];
   },
   set: function(stencil){
     if (stencil instanceof this.$.oStencil) var stencil = stencil.name
-    this.$.debug("Setting current pen: "+ stencil)
+    log.debug("Setting current pen: "+ stencil)
     PenstyleManager.setCurrentPenstyleByName(stencil);
   }
 })
@@ -438,7 +436,7 @@ Object.defineProperty($.oApp.prototype, 'currentStencil', {
  * get a tool by its name
  * @return {$.oTool}   a oTool object representing the tool, or null if not found.
  */
-$.oApp.prototype.getToolByName = function(toolName){
+exports.oApp.prototype.getToolByName = function(toolName){
   var _tools  = this.tools;
   for (var i in _tools){
     if (_tools[i].name.toLowerCase() == toolName.toLowerCase()) return _tools[i];
@@ -452,7 +450,7 @@ $.oApp.prototype.getToolByName = function(toolName){
  * @param {$.oTool}     tool      the tool object we want valid stencils for
  * @return {$.oStencil[]}    the list of stencils compatible with the specified tool
  */
-$.oApp.prototype.getValidStencils = function (tool){
+exports.oApp.prototype.getValidStencils = function (tool){
   if (typeof tool === 'undefined') var tool = this.currentTool;
   return tool.stencils;
 }
@@ -463,7 +461,7 @@ $.oApp.prototype.getValidStencils = function (tool){
  * @param {string} menuName         The name of the menu containing the action (must be a top level menu such as File, Edit etc)
  * @param {string} menuString       The menu entry to trigger.
  */
-$.oApp.prototype.runMenuCommand = function(menuName, menuString){
+exports.oApp.prototype.runMenuCommand = function(menuName, menuString){
   var menubar = this.mainWindow.menuBar();
   var menus = menubar.children();
 
@@ -507,7 +505,7 @@ $.oApp.prototype.runMenuCommand = function(menuName, menuString){
  * @param       {QWidget}   [parent]           The parent widget to add the toolbar to.
  * @param       {bool}      [show]             Whether to show the toolbar instantly after creation.
  */
-$.oToolbar = function( name, widgets, parent, show ){
+exports.oToolbar = function( name, widgets, parent, show ){
   if (typeof parent === 'undefined') var parent = $.app.mainWindow;
   if (typeof widgets === 'undefined') var widgets = [];
   if (typeof show === 'undefined') var show = true;
@@ -524,9 +522,9 @@ $.oToolbar = function( name, widgets, parent, show ){
  * Shows the oToolbar.
  * @name    $.oToolbar#show
  */
-$.oToolbar.prototype.show = function(){
+exports.oToolbar.prototype.show = function(){
   if (this.$.batchMode) {
-    this.$.debug("$.oToolbar not supported in batch mode", this.$.DEBUG_LEVEL.ERROR)
+    log.debug("$.oToolbar not supported in batch mode", this.$.DEBUG_LEVEL.ERROR)
     return;
   }
 

--- a/openHarmony/openHarmony_application.js
+++ b/openHarmony/openHarmony_application.js
@@ -249,7 +249,7 @@ Object.defineProperty(exports.oApp.prototype, 'currentTool', {
         this.getToolByName(tool).activate();
         return
       }catch(err){
-        log.debug("'"+ tool + "' is not a valid tool name. Valid: "+this.tools.map(function(x){return x.name}).join(", "))
+        this.$.debug("'"+ tool + "' is not a valid tool name. Valid: "+this.tools.map(function(x){return x.name}).join(", "))
       }
     }
     if (typeof tool == "number"){
@@ -423,7 +423,7 @@ Object.defineProperty(exports.oApp.prototype, 'currentStencil', {
   },
   set: function(stencil){
     if (stencil instanceof this.$.oStencil) var stencil = stencil.name
-    log.debug("Setting current pen: "+ stencil)
+    this.$.debug("Setting current pen: "+ stencil)
     PenstyleManager.setCurrentPenstyleByName(stencil);
   }
 })
@@ -524,7 +524,7 @@ exports.oToolbar = function( name, widgets, parent, show ){
  */
 exports.oToolbar.prototype.show = function(){
   if (this.$.batchMode) {
-    log.debug("$.oToolbar not supported in batch mode", this.$.DEBUG_LEVEL.ERROR)
+    this.$.debug("$.oToolbar not supported in batch mode", this.$.DEBUG_LEVEL.ERROR)
     return;
   }
 

--- a/openHarmony/openHarmony_application.js
+++ b/openHarmony/openHarmony_application.js
@@ -240,7 +240,7 @@ Object.defineProperty(exports.oApp.prototype, 'currentTool', {
     return _tool;
   },
   set : function(tool){
-    if (tool instanceof oTool) {
+    if (tool instanceof this.$.oTool) {
       tool.activate();
       return
     }

--- a/openHarmony/openHarmony_attribute.js
+++ b/openHarmony/openHarmony_attribute.js
@@ -81,7 +81,7 @@
  * myNode.position.x = 5;
  *
  */
-$.oAttribute = function( oNodeObject, attributeObject, parentAttribute ){
+exports.oAttribute = function( oNodeObject, attributeObject, parentAttribute ){
   this._type = "attribute";
 
   this.node = oNodeObject;
@@ -107,7 +107,7 @@ $.oAttribute = function( oNodeObject, attributeObject, parentAttribute ){
  * @private
  * @return  {void}   Nothing returned.
  */
-$.oAttribute.prototype.createSubAttributes = function (attributeObject){
+exports.oAttribute.prototype.createSubAttributes = function (attributeObject){
   var _subAttributes = [];
 
   // if harmony version supports getSubAttributes
@@ -142,7 +142,7 @@ $.oAttribute.prototype.createSubAttributes = function (attributeObject){
  * @deprecated
  * @return  {void}   Nothing returned.
  */
-$.oAttribute.prototype.getSubAttributes_oldVersion = function (){
+exports.oAttribute.prototype.getSubAttributes_oldVersion = function (){
   var sub_attrs = [];
 
   switch( this.type ){
@@ -182,7 +182,7 @@ $.oAttribute.prototype.getSubAttributes_oldVersion = function (){
  * @name $.oAttribute#name
  * @type {string}
  */
-Object.defineProperty($.oAttribute.prototype, 'name', {
+Object.defineProperty(exports.oAttribute.prototype, 'name', {
   get: function(){
     return this.attributeObject.name();
   }
@@ -193,7 +193,7 @@ Object.defineProperty($.oAttribute.prototype, 'name', {
  * @name $.oAttribute#keyword
  * @type {string}
  */
-Object.defineProperty($.oAttribute.prototype, 'keyword', {
+Object.defineProperty(exports.oAttribute.prototype, 'keyword', {
     get : function(){
         // formatting the keyword for our purposes
         // hard coding a fix for 3DPath attribute name which starts with a number
@@ -209,7 +209,7 @@ Object.defineProperty($.oAttribute.prototype, 'keyword', {
  * @name $.oAttribute#shortKeyword
  * @type {string}
  */
-Object.defineProperty($.oAttribute.prototype, 'shortKeyword', {
+Object.defineProperty(exports.oAttribute.prototype, 'shortKeyword', {
     get : function(){
         // formatting the keyword for our purposes
         // hard coding a fix for 3DPath attribute name which starts with a number
@@ -225,7 +225,7 @@ Object.defineProperty($.oAttribute.prototype, 'shortKeyword', {
  * @name $.oAttribute#type
  * @type {string}
  */
-Object.defineProperty($.oAttribute.prototype, 'type', {
+Object.defineProperty(exports.oAttribute.prototype, 'type', {
     get : function(){
         return this.attributeObject.typeName();
     }
@@ -246,7 +246,7 @@ myNode.attributes.position.x.addColumn(); // if the column exist already, it wil
 // to unlink a column, just set it to null/undefined:
 myNode.attributes.position.x.column = null; // values are no longer animated.
  */
-Object.defineProperty($.oAttribute.prototype, 'column', {
+Object.defineProperty(exports.oAttribute.prototype, 'column', {
   get : function(){
     var _column = node.linkedColumn ( this.node.path, this._keyword );
     if( _column && _column.length ){
@@ -274,7 +274,7 @@ Object.defineProperty($.oAttribute.prototype, 'column', {
  * @name $.oAttribute#frames
  * @type {$.oFrame[]}
  */
-Object.defineProperty($.oAttribute.prototype, 'frames', {
+Object.defineProperty(exports.oAttribute.prototype, 'frames', {
     get : function(){
          var _column = this.column
          if (_column != null){
@@ -297,7 +297,7 @@ Object.defineProperty($.oAttribute.prototype, 'frames', {
  * @type {$.oFrame[]}
  */
 // MCNote: I would prefer if this could remain getKeyFrames()
-Object.defineProperty($.oAttribute.prototype, 'keyframes', {
+Object.defineProperty(exports.oAttribute.prototype, 'keyframes', {
     get : function(){
       var col     = this.column;
       var frames  = this.frames;
@@ -321,7 +321,7 @@ Object.defineProperty($.oAttribute.prototype, 'keyframes', {
  * @private
  */
 //CF Note: Not sure if this should be a general attribute, or a subattribute.
-Object.defineProperty($.oAttribute.prototype, "useSeparate", {
+Object.defineProperty(exports.oAttribute.prototype, "useSeparate", {
     get : function(){
         // TODO
         throw new Error("not yet implemented");
@@ -346,7 +346,7 @@ Object.defineProperty($.oAttribute.prototype, "useSeparate", {
  *
  * myAttribute.setValue(myAttribute.defaultValue);
  */
-Object.defineProperty($.oAttribute.prototype, "defaultValue", {
+Object.defineProperty(exports.oAttribute.prototype, "defaultValue", {
     get : function(){
         // TODO: we could use this to reset bones/deformers to their rest states
         var _keyword = this._keyword;
@@ -409,7 +409,7 @@ Object.defineProperty($.oAttribute.prototype, "defaultValue", {
  * Provides the keyframes of the attribute.
  * @return {$.oFrame[]}   The filtered keyframes.
  */
-$.oAttribute.prototype.getKeyframes = function(){
+exports.oAttribute.prototype.getKeyframes = function(){
     var _frames = this.frames;
     _frames = _frames.filter(function(x){return x.isKeyframe});
     return _frames;
@@ -421,7 +421,7 @@ $.oAttribute.prototype.getKeyframes = function(){
  * @return {$.oFrame[]}   The filtered keyframes.
  * @deprecated For case consistency, keyframe will never have a capital F
  */
-$.oAttribute.prototype.getKeyFrames = function(){
+exports.oAttribute.prototype.getKeyFrames = function(){
     this.$.debug("oAttribute.getKeyFrames is deprecated. Use oAttribute.getKeyframes instead.", this.$.DEBUG_LEVEL.ERROR);
     var _frames = this.frames;
     _frames = _frames.filter(function(x){return x.isKeyframe});
@@ -433,7 +433,7 @@ $.oAttribute.prototype.getKeyFrames = function(){
  * Recursively get all the columns linked to the attribute and its subattributes
  * @return {$.oColumn[]}    the list of columns linked to the subattributes
  */
-$.oAttribute.prototype.getLinkedColumns = function(){
+exports.oAttribute.prototype.getLinkedColumns = function(){
   var _columns = [];
   var _subAttributes = this.subAttributes;
   var _ownColumn = this.column;
@@ -452,7 +452,7 @@ $.oAttribute.prototype.getLinkedColumns = function(){
  * @param {bool}    [duplicateColumns=false]      In the case that the attribute has a column, wether to duplicate the column before linking
  * @private
  */
-$.oAttribute.prototype.setToAttributeValue = function(attributeToCopy, duplicateColumns){
+exports.oAttribute.prototype.setToAttributeValue = function(attributeToCopy, duplicateColumns){
   if (typeof duplicateColumns === 'undefined') var duplicateColumns = false;
 
   if (this.keyword !== attributeToCopy.keyword) return;
@@ -481,7 +481,7 @@ $.oAttribute.prototype.setToAttributeValue = function(attributeToCopy, duplicate
  *
  * @return {object}      The value of the attribute in the native format of that attribute (contextual to the attribute).
  */
-$.oAttribute.prototype.getValue = function (frame) {
+exports.oAttribute.prototype.getValue = function (frame) {
     if (typeof frame === 'undefined') var frame = 1;
     this.$.debug('getting value of frame :'+frame+' of attribute: '+this._keyword+' of node '+this.node+' - type '+this.type, this.$.DEBUG_LEVEL.LOG)
 
@@ -587,7 +587,7 @@ $.oAttribute.prototype.getValue = function (frame) {
  * @param   {string}     value        The value to set on the attribute.
  * @param   {int}        [frame=1]    The frame at which to set the value, if not set, assumes 1
  */
-$.oAttribute.prototype.setValue = function (value, frame) {
+exports.oAttribute.prototype.setValue = function (value, frame) {
     var _attr = this.attributeObject;
     var _column = this.column;
     var _type = this.type;
@@ -671,7 +671,7 @@ $.oAttribute.prototype.setValue = function (value, frame) {
  * If a column already exists, it returns it.
  * @returns {$.oColumn} the created column
  */
-$.oAttribute.prototype.addColumn = function(){
+exports.oAttribute.prototype.addColumn = function(){
   var _column = this.column;
   if (_column) return _column;
 
@@ -725,7 +725,7 @@ $.oAttribute.prototype.addColumn = function(){
  * @deprecated use oAttribute.getValue(frame) instead (see: function names as verbs)
  * @return {object}      The value of the attribute in the native format of that attribute (contextual to the attribute).
  */
-$.oAttribute.prototype.value = function(frame){
+exports.oAttribute.prototype.value = function(frame){
   return this.getValue( frame );
 }
 
@@ -735,6 +735,6 @@ $.oAttribute.prototype.value = function(frame){
  * @private
  * @returns {string}
  */
-$.oAttribute.prototype.toString = function(){
+exports.oAttribute.prototype.toString = function(){
   return "[object $.oAttribute '"+this.keyword+(this.subAttributes.length?"' subAttributes: "+this.subAttributes.map(function(x){return x.shortKeyword}):"")+"]";
 }

--- a/openHarmony/openHarmony_backdrop.js
+++ b/openHarmony/openHarmony_backdrop.js
@@ -82,7 +82,7 @@
  *  }
  * }
  */
-$.oBackdrop = function( groupPath, backdropObject ){
+exports.oBackdrop = function( groupPath, backdropObject ){
   this.group = ( groupPath instanceof this.$.oGroupNode )? groupPath.path: groupPath;
 	this.backdropObject = backdropObject;
 }
@@ -93,7 +93,7 @@ $.oBackdrop = function( groupPath, backdropObject ){
  * @name $.oBackdrop#index
  * @type {int}
  */
-Object.defineProperty($.oBackdrop.prototype, 'index', {
+Object.defineProperty(exports.oBackdrop.prototype, 'index', {
     get : function(){
       var _groupBackdrops = Backdrop.backdrops(this.group).map(function(x){return x.title.text})
 		  return _groupBackdrops.indexOf(this.title)
@@ -106,7 +106,7 @@ Object.defineProperty($.oBackdrop.prototype, 'index', {
  * @name $.oBackdrop#title
  * @type {string}
  */
-Object.defineProperty($.oBackdrop.prototype, 'title', {
+Object.defineProperty(exports.oBackdrop.prototype, 'title', {
   get : function(){
     var _title = this.backdropObject.title.text;
     return _title;
@@ -141,7 +141,7 @@ Object.defineProperty($.oBackdrop.prototype, 'title', {
  * @name $.oBackdrop#body
  * @type {string}
  */
-Object.defineProperty($.oBackdrop.prototype, 'body', {
+Object.defineProperty(exports.oBackdrop.prototype, 'body', {
     get : function(){
          var _title = this.backdropObject.description.text;
          return _title;
@@ -164,7 +164,7 @@ Object.defineProperty($.oBackdrop.prototype, 'body', {
  * @name $.oBackdrop#titleFont
  * @type {object}
  */
-Object.defineProperty($.oBackdrop.prototype, 'titleFont', {
+Object.defineProperty(exports.oBackdrop.prototype, 'titleFont', {
     get : function(){
          var _font = {family : this.backdropObject.title.font,
                       size : this.backdropObject.title.size,
@@ -191,7 +191,7 @@ Object.defineProperty($.oBackdrop.prototype, 'titleFont', {
  * @name $.oBackdrop#bodyFont
  * @type {object}
  */
-Object.defineProperty($.oBackdrop.prototype, 'bodyFont', {
+Object.defineProperty(exports.oBackdrop.prototype, 'bodyFont', {
     get : function(){
          var _font = {family : this.backdropObject.description.font,
                       size : this.backdropObject.description.size,
@@ -219,7 +219,7 @@ Object.defineProperty($.oBackdrop.prototype, 'bodyFont', {
  * @type {$.oNode[]}
  * @readonly
  */
- Object.defineProperty($.oBackdrop.prototype, 'parent', {
+ Object.defineProperty(exports.oBackdrop.prototype, 'parent', {
   get : function(){
     if (!this.hasOwnProperty("_parent")){
       this._parent = this.$.scn.getNodeByPath(this.group);
@@ -235,7 +235,7 @@ Object.defineProperty($.oBackdrop.prototype, 'bodyFont', {
  * @type {$.oNode[]}
  * @readonly
  */
-Object.defineProperty($.oBackdrop.prototype, 'nodes', {
+Object.defineProperty(exports.oBackdrop.prototype, 'nodes', {
   get : function(){
     var _nodes = this.parent.nodes;
     var _bounds = this.bounds;
@@ -252,7 +252,7 @@ Object.defineProperty($.oBackdrop.prototype, 'nodes', {
  * @name $.oBackdrop#x
  * @type {float}
  */
-Object.defineProperty($.oBackdrop.prototype, 'x', {
+Object.defineProperty(exports.oBackdrop.prototype, 'x', {
   get : function(){
     var _x = this.backdropObject.position.x;
     return _x;
@@ -275,7 +275,7 @@ Object.defineProperty($.oBackdrop.prototype, 'x', {
  * @name $.oBackdrop#y
  * @type {float}
  */
-Object.defineProperty($.oBackdrop.prototype, 'y', {
+Object.defineProperty(exports.oBackdrop.prototype, 'y', {
   get : function(){
     var _y = this.backdropObject.position.y;
     return _y;
@@ -298,7 +298,7 @@ Object.defineProperty($.oBackdrop.prototype, 'y', {
  * @name $.oBackdrop#width
  * @type {float}
  */
-Object.defineProperty($.oBackdrop.prototype, 'width', {
+Object.defineProperty(exports.oBackdrop.prototype, 'width', {
   get : function(){
     var _width = this.backdropObject.position.w;
     return _width;
@@ -322,7 +322,7 @@ Object.defineProperty($.oBackdrop.prototype, 'width', {
  * @memberof $.oBackdrop#
  * @type {float}
  */
-Object.defineProperty($.oBackdrop.prototype, 'height', {
+Object.defineProperty(exports.oBackdrop.prototype, 'height', {
   get : function(){
     var _height = this.backdropObject.position.h;
     return _height;
@@ -345,7 +345,7 @@ Object.defineProperty($.oBackdrop.prototype, 'height', {
  * @name $.oBackdrop#position
  * @type {oPoint}
  */
-Object.defineProperty($.oBackdrop.prototype, 'position', {
+Object.defineProperty(exports.oBackdrop.prototype, 'position', {
   get : function(){
     var _position = new oPoint(this.x, this.y, this.index)
     return _position;
@@ -369,7 +369,7 @@ Object.defineProperty($.oBackdrop.prototype, 'position', {
  * @name $.oBackdrop#bounds
  * @type {oBox}
  */
-Object.defineProperty($.oBackdrop.prototype, 'bounds', {
+Object.defineProperty(exports.oBackdrop.prototype, 'bounds', {
   get : function(){
     var _box = new oBox(this.x, this.y, this.width+this.x, this.height+this.y)
     return _box;
@@ -395,7 +395,7 @@ Object.defineProperty($.oBackdrop.prototype, 'bounds', {
  * @name $.oBackdrop#color
  * @type {oColorValue}
  */
-Object.defineProperty($.oBackdrop.prototype, 'color', {
+Object.defineProperty(exports.oBackdrop.prototype, 'color', {
   get : function(){
     var _color = this.backdropObject.color;
     // TODO: get the rgba values from the int

--- a/openHarmony/openHarmony_backdrop.js
+++ b/openHarmony/openHarmony_backdrop.js
@@ -168,7 +168,7 @@ Object.defineProperty(exports.oBackdrop.prototype, 'titleFont', {
     get : function(){
          var _font = {family : this.backdropObject.title.font,
                       size : this.backdropObject.title.size,
-                      color : ( new oColorValue() ).parseColorFromInt(this.backdropObject.title.color)}
+                      color : ( new this.$.oColorValue() ).parseColorFromInt(this.backdropObject.title.color)}
          return _font;
     },
 
@@ -195,7 +195,7 @@ Object.defineProperty(exports.oBackdrop.prototype, 'bodyFont', {
     get : function(){
          var _font = {family : this.backdropObject.description.font,
                       size : this.backdropObject.description.size,
-                      color : ( new oColorValue() ).parseColorFromInt(this.backdropObject.description.color)}
+                      color : ( new this.$.oColorValue() ).parseColorFromInt(this.backdropObject.description.color)}
          return _font;
     },
 
@@ -347,7 +347,7 @@ Object.defineProperty(exports.oBackdrop.prototype, 'height', {
  */
 Object.defineProperty(exports.oBackdrop.prototype, 'position', {
   get : function(){
-    var _position = new oPoint(this.x, this.y, this.index)
+    var _position = new this.$.oPoint(this.x, this.y, this.index)
     return _position;
   },
 
@@ -371,7 +371,7 @@ Object.defineProperty(exports.oBackdrop.prototype, 'position', {
  */
 Object.defineProperty(exports.oBackdrop.prototype, 'bounds', {
   get : function(){
-    var _box = new oBox(this.x, this.y, this.width+this.x, this.height+this.y)
+    var _box = new this.$.oBox(this.x, this.y, this.width+this.x, this.height+this.y)
     return _box;
   },
 
@@ -403,7 +403,7 @@ Object.defineProperty(exports.oBackdrop.prototype, 'color', {
   },
 
   set : function(newOColorValue){
-    var _color = new oColorValue(newOColorValue);
+    var _color = new this.$.oColorValue(newOColorValue);
     var _index = this.index;
 
     var _backdrops = Backdrop.backdrops(this.group);

--- a/openHarmony/openHarmony_color.js
+++ b/openHarmony/openHarmony_color.js
@@ -69,7 +69,7 @@
  * var myBackdrop.color = myColor                             // can be used to set the color of a backdrop
  *
  */
-$.oColorValue = function( colorValue ){
+exports.oColorValue = function( colorValue ){
     if (typeof colorValue === 'undefined') var colorValue = "#000000ff";
 
     this.r = 0;
@@ -109,7 +109,7 @@ $.oColorValue = function( colorValue ){
  * Creates an int from the color value, as used for backdrop colors.
  * @return: {string}       ALPHA<<24  RED<<16  GREEN<<8  BLUE
  */
-$.oColorValue.prototype.toInt = function (){
+exports.oColorValue.prototype.toInt = function (){
      return ((this.a & 0xff) << 24) | ((this.r & 0xff) << 16) | ((this.g & 0xff) << 8) | (this.b & 0xff);
 }
 
@@ -118,7 +118,7 @@ $.oColorValue.prototype.toInt = function (){
  * The colour value represented as a string.
  * @return: {string}       RGBA components in a string in format #RRGGBBAA
  */
-$.oColorValue.prototype.toString = function (){
+exports.oColorValue.prototype.toString = function (){
     var _hex = "#";
 
     var r = ("00"+this.r.toString(16)).slice(-2);
@@ -135,7 +135,7 @@ $.oColorValue.prototype.toString = function (){
  * The colour value represented as a string.
  * @return: {string}       RGBA components in a string in format #RRGGBBAA
  */
-$.oColorValue.prototype.toHex = function (){
+exports.oColorValue.prototype.toHex = function (){
   return this.toString();
 }
 
@@ -143,12 +143,12 @@ $.oColorValue.prototype.toHex = function (){
  * Ingest a hex string in form #RRGGBBAA to define the colour.
  * @param   {string}    hexString                The colour in form #RRGGBBAA
  */
-$.oColorValue.prototype.fromColorString = function (hexString){
+exports.oColorValue.prototype.fromColorString = function (hexString){
     hexString = hexString.replace("#","");
     if (hexString.length == 6) hexString += "ff";
     if (hexString.length != 8) throw new Error("incorrect color string format");
 
-    this.$.debug( "HEX : " + hexString, this.$.DEBUG_LEVEL.LOG);
+    // this.$.debug( "HEX : " + hexString, this.$.DEBUG_LEVEL.LOG);
 
     this.r = parseInt(hexString.slice(0,2), 16);
     this.g = parseInt(hexString.slice(2,4), 16);
@@ -161,7 +161,7 @@ $.oColorValue.prototype.fromColorString = function (hexString){
  * Uses a color integer (used in backdrops) and parses the INT; applies the RGBA components of the INT to thos oColorValue
  * @param   { int }    colorInt                      24 bit-shifted integer containing RGBA values
  */
-$.oColorValue.prototype.parseColorFromInt = function(colorInt){
+exports.oColorValue.prototype.parseColorFromInt = function(colorInt){
 	this.r = colorInt >> 16 & 0xFF;
 	this.g = colorInt >> 8 & 0xFF;
 	this.b = colorInt & 0xFF;
@@ -174,7 +174,7 @@ $.oColorValue.prototype.parseColorFromInt = function(colorInt){
  * @name $.oColorValue#h
  * @type {float}
  */
-Object.defineProperty($.oColorValue.prototype, 'h', {
+Object.defineProperty(exports.oColorValue.prototype, 'h', {
     get : function(){
         var r = this.r;
         var g = this.g;
@@ -256,7 +256,7 @@ Object.defineProperty($.oColorValue.prototype, 'h', {
  * @name $.oColorValue#s
  * @type {float}
  */
-Object.defineProperty($.oColorValue.prototype, 's', {
+Object.defineProperty(exports.oColorValue.prototype, 's', {
     get : function(){
         var r = this.r;
         var g = this.g;
@@ -315,7 +315,7 @@ Object.defineProperty($.oColorValue.prototype, 's', {
  * @name $.oColorValue#l
  * @type {float}
  */
-Object.defineProperty($.oColorValue.prototype, 'l', {
+Object.defineProperty(exports.oColorValue.prototype, 'l', {
     get : function(){
         var r = this.r;
         var g = this.g;
@@ -391,7 +391,7 @@ Object.defineProperty($.oColorValue.prototype, 'l', {
  *
  * @property {$.oPalette}            palette                    The palette to which the color belongs.
  */
-$.oColor = function( oPaletteObject, index ){
+exports.oColor = function( oPaletteObject, index ){
   // We don't use id in the constructor as multiple colors with the same id can exist in the same palette.
   this._type = "color";
 
@@ -406,7 +406,7 @@ $.oColor = function( oPaletteObject, index ){
  * @name $.oColor#colorObject
  * @type {BaseColor}
  */
-Object.defineProperty($.oColor.prototype, 'colorObject', {
+Object.defineProperty(exports.oColor.prototype, 'colorObject', {
     get : function(){
         return this.palette.paletteObject.getColorByIndex(this._index);
     }
@@ -419,7 +419,7 @@ Object.defineProperty($.oColor.prototype, 'colorObject', {
  * @name $.oColor#name
  * @type {string}
  */
-Object.defineProperty($.oColor.prototype, 'name', {
+Object.defineProperty(exports.oColor.prototype, 'name', {
     get : function(){
         var _color = this.colorObject;
         return _color.name;
@@ -437,7 +437,7 @@ Object.defineProperty($.oColor.prototype, 'name', {
  * @name $.oColor#id
  * @type {string}
  */
-Object.defineProperty($.oColor.prototype, 'id', {
+Object.defineProperty(exports.oColor.prototype, 'id', {
     get : function(){
         var _color = this.colorObject;
         return _color.id
@@ -455,7 +455,7 @@ Object.defineProperty($.oColor.prototype, 'id', {
  * @name $.oColor#index
  * @type {int}
  */
-Object.defineProperty($.oColor.prototype, 'index', {
+Object.defineProperty(exports.oColor.prototype, 'index', {
     get : function(){
         return this._index;
     },
@@ -472,7 +472,7 @@ Object.defineProperty($.oColor.prototype, 'index', {
  * @name $.oColor#type
  * @type {int}
  */
-Object.defineProperty($.oColor.prototype, 'type', {
+Object.defineProperty(exports.oColor.prototype, 'type', {
     set : function(){
       throw new Error("setting oColor.type Not yet implemented.");
     },
@@ -499,7 +499,7 @@ Object.defineProperty($.oColor.prototype, 'type', {
  * @name $.oColor#selected
  * @type {bool}
  */
-Object.defineProperty($.oColor.prototype, 'selected', {
+Object.defineProperty(exports.oColor.prototype, 'selected', {
     get : function(){
         var _currentId = PaletteManager.getCurrentColorId()
         var _colors = this.palette.colors;
@@ -522,7 +522,7 @@ Object.defineProperty($.oColor.prototype, 'selected', {
  * @name $.oColor#value
  * @type {$.oColorValue}
  */
-Object.defineProperty($.oColor.prototype, 'value', {
+Object.defineProperty(exports.oColor.prototype, 'value', {
   get : function(){
     var _color = this.colorObject;
 
@@ -549,7 +549,7 @@ Object.defineProperty($.oColor.prototype, 'value', {
 
     switch(this.type){
       case "solid":
-        _value = new $.oColorValue(newValue);
+        _value = new this.$.oColorValue(newValue);
         _color.setColorData(_value);
         break;
       case "texture":
@@ -582,7 +582,7 @@ Object.defineProperty($.oColor.prototype, 'value', {
  *
  * @return: {$.oColor}           The new resulting $.oColor object.
  */
-$.oColor.prototype.moveToPalette = function (oPaletteObject, index){
+exports.oColor.prototype.moveToPalette = function (oPaletteObject, index){
     if (typeof index === 'undefined') var index = oPaletteObject.paletteObject.nColors;
     var _duplicate = this.copyToPalette(oPaletteObject, index)
     this.remove()
@@ -598,7 +598,7 @@ $.oColor.prototype.moveToPalette = function (oPaletteObject, index){
  *
  * @return: {$.oColor}           The new resulting $.oColor object.
  */
-$.oColor.prototype.copyToPalette = function (oPaletteObject, index){
+exports.oColor.prototype.copyToPalette = function (oPaletteObject, index){
     var _color = this.colorObject;
 
     oPaletteObject.paletteObject.cloneColor(_color);
@@ -614,7 +614,7 @@ $.oColor.prototype.copyToPalette = function (oPaletteObject, index){
 /**
  * Removes the color from the palette it belongs to.
  */
-$.oColor.prototype.remove = function (){
+exports.oColor.prototype.remove = function (){
     // TODO: find a way to work with index as more than one color can have the same id
     this.palette.paletteObject.removeColor(this.id);
 }
@@ -627,7 +627,7 @@ $.oColor.prototype.remove = function (){
  * @static
  * @return: { string }    Hex color string in format #FFFFFFFF.
  */
-$.oColor.prototype.rgbaToHex = function (rgbaObject){
+exports.oColor.prototype.rgbaToHex = function (rgbaObject){
     var _hex = "#";
     _hex += rvbObject.r.toString(16)
     _hex += rvbObject.g.toString(16)
@@ -645,7 +645,7 @@ $.oColor.prototype.rgbaToHex = function (rgbaObject){
  * @static
  * @return: { obj }    The hex object returned { r:int, g:int, b:int, a:int }
  */
-$.oColor.prototype.hexToRgba = function (hexString){
+exports.oColor.prototype.hexToRgba = function (hexString){
     var _rgba = {};
     //Needs a better fail state.
 

--- a/openHarmony/openHarmony_column.js
+++ b/openHarmony/openHarmony_column.js
@@ -83,7 +83,7 @@
  *
  * doc.nodes[0].attributes.position.y.column = myColumn;  // now position.x and position.y will share the same animation on the node.
  */
-$.oColumn = function( uniqueName, oAttributeObject ){
+exports.oColumn = function( uniqueName, oAttributeObject ){
   var instance = this.$.getInstanceFromCache.call(this, uniqueName);
   if (instance) return instance;
 
@@ -109,7 +109,7 @@ $.oColumn = function( uniqueName, oAttributeObject ){
  * @name $.oColumn#name
  * @type {string}
  */
-Object.defineProperty( $.oColumn.prototype, 'name', {
+Object.defineProperty( exports.oColumn.prototype, 'name', {
     get : function(){
          return column.getDisplayName(this.uniqueName);
     },
@@ -131,7 +131,7 @@ Object.defineProperty( $.oColumn.prototype, 'name', {
  * @readonly
  * @type {string}
  */
-Object.defineProperty( $.oColumn.prototype, 'type', {
+Object.defineProperty( exports.oColumn.prototype, 'type', {
     get : function(){
         return column.type(this.uniqueName)
     }
@@ -143,7 +143,7 @@ Object.defineProperty( $.oColumn.prototype, 'type', {
  * @name $.oColumn#selected
  * @type {bool}
  */
-Object.defineProperty($.oColumn.prototype, 'selected', {
+Object.defineProperty(exports.oColumn.prototype, 'selected', {
     get : function(){
         var sel_num = selection.numberOfColumnsSelected();
         for( var n=0;n<sel_num;n++ ){
@@ -167,7 +167,7 @@ Object.defineProperty($.oColumn.prototype, 'selected', {
  * @type {$.oFrame[]}
  * @readonly
  */
-Object.defineProperty($.oColumn.prototype, 'frames', {
+Object.defineProperty(exports.oColumn.prototype, 'frames', {
     get : function(){
         while( this._cacheFrames.length < frame.numberOf()+1 ){
           this._cacheFrames.push( new this.$.oFrame( this._cacheFrames.length, this ) );
@@ -184,7 +184,7 @@ Object.defineProperty($.oColumn.prototype, 'frames', {
  * @readonly
  * @type {$.oFrame[]}
  */
-Object.defineProperty($.oColumn.prototype, 'keyframes', {
+Object.defineProperty(exports.oColumn.prototype, 'keyframes', {
     get : function(){
       return this.getKeyframes();
     }
@@ -197,7 +197,7 @@ Object.defineProperty($.oColumn.prototype, 'keyframes', {
  * @readonly
  * @type {object}
  */
-Object.defineProperty($.oColumn.prototype, 'subColumns', {
+Object.defineProperty(exports.oColumn.prototype, 'subColumns', {
     get : function(){
       //CF Note: Not sure of this use.
       //MC > allows to loop through subcolumns if they exist
@@ -217,7 +217,7 @@ Object.defineProperty($.oColumn.prototype, 'subColumns', {
  * @readonly
  * @type {object}
  */
-Object.defineProperty($.oColumn.prototype, 'easeType', {
+Object.defineProperty(exports.oColumn.prototype, 'easeType', {
     get : function(){
         switch(this.type){
             case "BEZIER":
@@ -237,7 +237,7 @@ Object.defineProperty($.oColumn.prototype, 'easeType', {
  * @name $.oColumn#stepSection
  * @type {object}
  */
-Object.defineProperty($.oColumn.prototype, 'stepSection', {
+Object.defineProperty(exports.oColumn.prototype, 'stepSection', {
   get : function(){
     var _columnName = this.uniqueName;
     var _section = {
@@ -262,7 +262,7 @@ Object.defineProperty($.oColumn.prototype, 'stepSection', {
 /**
  * Deletes the column from the scene. The column must be unlinked from any attribute first.
  */
-$.oColumn.prototype.remove = function(){
+exports.oColumn.prototype.remove = function(){
   column.removeUnlinkedFunctionColumn(this.name);
   if (this.type) throw new Error("Couldn't remove column "+this.name+", unlink it from any attribute first.")
 }
@@ -275,7 +275,7 @@ $.oColumn.prototype.remove = function(){
  * @param   {int}         amount               The amount to extend.
  * @param   {bool}        replace              Setting this to false will insert frames as opposed to overwrite existing ones.
  */
-$.oColumn.prototype.extendExposures = function( exposures, amount, replace){
+exports.oColumn.prototype.extendExposures = function( exposures, amount, replace){
     if (this.type != "DRAWING") return false;
     // if amount is undefined, extend function below will automatically fill empty frames
 
@@ -291,7 +291,7 @@ $.oColumn.prototype.extendExposures = function( exposures, amount, replace){
 /**
  * Removes concurrent/duplicate keys from drawing layers.
  */
-$.oColumn.prototype.removeDuplicateKeys = function(){
+exports.oColumn.prototype.removeDuplicateKeys = function(){
     var _keys = this.getKeyframes();
 
     var _pointsToRemove = [];
@@ -333,7 +333,7 @@ $.oColumn.prototype.removeDuplicateKeys = function(){
  *
  * @return {$.oColumn}                The column generated.
  */
-$.oColumn.prototype.duplicate = function(newAttribute) {
+exports.oColumn.prototype.duplicate = function(newAttribute) {
   var _duplicateColumn = this.$.scene.addColumn(this.type, this.name);
 
   // linking to an attribute if one is provided
@@ -373,7 +373,7 @@ $.oColumn.prototype.duplicate = function(newAttribute) {
  *
  * @return {$.oFrame[]}    Provides the array of frames from the column.
  */
-$.oColumn.prototype.getKeyframes = function(){
+exports.oColumn.prototype.getKeyframes = function(){
   var _frames = this.frames;
 
   var _ease = this.easeType;
@@ -401,7 +401,7 @@ $.oColumn.prototype.getKeyframes = function(){
  * @deprecated For case consistency, keyframe will never have a capital F
  * @return {$.oFrame[]}    Provides the array of frames from the column.
  */
-$.oColumn.prototype.getKeyFrames = function(){
+exports.oColumn.prototype.getKeyFrames = function(){
   this.$.debug("oColumn.getKeyFrames is deprecated. Use oColumn.getKeyframes instead.", this.$.DEBUG_LEVEL.ERROR);
   return this.keyframes;
 }
@@ -412,7 +412,7 @@ $.oColumn.prototype.getKeyFrames = function(){
  * @param {int}  [frame=1]       The frame at which to get the value
  * @return  {various}            The value of the column, can be different types depending on column type.
  */
-$.oColumn.prototype.getValue = function(frame){
+exports.oColumn.prototype.getValue = function(frame){
   if (typeof frame === 'undefined') var frame = 1;
 
   // this.$.log("Getting value of frame "+this.frameNumber+" of column "+this.column.name)
@@ -437,7 +437,7 @@ $.oColumn.prototype.getValue = function(frame){
  * @param {various}   newValue        The new value to set the column to
  * @param {int}       [frame=1]       The frame at which to get the value
  */
-$.oColumn.prototype.setValue = function(newValue, frame){
+exports.oColumn.prototype.setValue = function(newValue, frame){
   if (typeof frame === 'undefined') var frame = 1;
 
   if (this.attributeObject){
@@ -465,7 +465,7 @@ $.oColumn.prototype.setValue = function(newValue, frame){
  *
  * @return  {int}    The index within that timeline.
  */
-$.oColumn.prototype.getTimelineLayer = function(timeline){
+exports.oColumn.prototype.getTimelineLayer = function(timeline){
   if (typeof timeline === 'undefined') var timeline = this.$.scene.getTimeline();
 
   var _columnNames = timeline.allLayers.map(function(x){return x.column?x.column.uniqueName:null});
@@ -493,7 +493,7 @@ $.oColumn.prototype.getTimelineLayer = function(timeline){
  *   }
  * }
  */
-$.oColumn.prototype.interpolateValueAtFrame = function(percentage, frameNumber){
+exports.oColumn.prototype.interpolateValueAtFrame = function(percentage, frameNumber){
   if (this.keyframes.length < 2) throw new Error("Can't interpolate, column "+this.name+" has less than two keys.");
   if (typeof frameNumber === 'undefined') var frameNumber = this.$.scn.currentFrame;
   if (typeof percentage === 'undefined') var percentage = 50;
@@ -528,7 +528,7 @@ $.oColumn.prototype.interpolateValueAtFrame = function(percentage, frameNumber){
 /**
  * @private
  */
- $.oColumn.prototype.toString = function(){
+ exports.oColumn.prototype.toString = function(){
   return "[object $.oColumn '"+this.name+"']"
 }
 
@@ -555,7 +555,7 @@ $.oColumn.prototype.interpolateValueAtFrame = function(percentage, frameNumber){
  * @property {string}                  uniqueName                  The unique name of the column.
  * @property {$.oAttribute}            attributeObject             The attribute object that the column is attached to.
  */
-$.oDrawingColumn = function( uniqueName, oAttributeObject ) {
+exports.oDrawingColumn = function( uniqueName, oAttributeObject ) {
   // $.oDrawingColumn can only represent a column of type 'DRAWING'
     if (column.type(uniqueName) != 'DRAWING') throw new Error("'uniqueName' parameter must point to a 'DRAWING' type node");
     //MessageBox.information("getting an instance of $.oDrawingColumn for column : "+uniqueName)
@@ -565,8 +565,8 @@ $.oDrawingColumn = function( uniqueName, oAttributeObject ) {
 
 
 // extends $.oColumn and can use its methods
-$.oDrawingColumn.prototype = Object.create($.oColumn.prototype);
-$.oDrawingColumn.prototype.constructor = $.oColumn;
+exports.oDrawingColumn.prototype = Object.create(exports.oColumn.prototype);
+exports.oDrawingColumn.prototype.constructor = exports.oColumn;
 
 
 /**
@@ -574,7 +574,7 @@ $.oDrawingColumn.prototype.constructor = $.oColumn;
  * @name $.oDrawingColumn#element
  * @type {$.oElement}
  */
-Object.defineProperty($.oDrawingColumn.prototype, 'element', {
+Object.defineProperty(exports.oDrawingColumn.prototype, 'element', {
     get : function(){
       // get info about synched layer if the column is fetched from the attribute (which is the case most of the time)
       var _synchedLayer = null;
@@ -597,7 +597,7 @@ Object.defineProperty($.oDrawingColumn.prototype, 'element', {
  * @param   {int}         [amount]               The number of frames to add to each exposure. If not specified, will extend frame up to the next one.
  * @param   {bool}        [replace=false]        Setting this to false will insert frames as opposed to overwrite existing ones.(currently unsupported))
  */
-$.oDrawingColumn.prototype.extendExposures = function( exposures, amount, replace){
+exports.oDrawingColumn.prototype.extendExposures = function( exposures, amount, replace){
     // if amount is undefined, extend function below will automatically fill empty frames
 
     if (typeof exposures === 'undefined' && typeof amount === 'undefined') {
@@ -625,7 +625,7 @@ $.oDrawingColumn.prototype.extendExposures = function( exposures, amount, replac
  *
  * @return {$.oColumn}    The created column.
  */
-$.oDrawingColumn.prototype.duplicate = function(newAttribute, duplicateElement) {
+exports.oDrawingColumn.prototype.duplicate = function(newAttribute, duplicateElement) {
   // duplicate element?
   if (typeof duplicateElement === 'undefined') var duplicateElement = true;
   var _duplicateElement = duplicateElement?this.element.duplicate():this.element;
@@ -654,7 +654,7 @@ $.oDrawingColumn.prototype.duplicate = function(newAttribute, duplicateElement) 
  * @param   {string}  [prefix]            a prefix to add to all names.
  * @param   {string}  [suffix]            a suffix to add to all names.
  */
-$.oDrawingColumn.prototype.renameAllByFrame = function(prefix, suffix){
+exports.oDrawingColumn.prototype.renameAllByFrame = function(prefix, suffix){
   if (typeof prefix === 'undefined') var prefix = "";
   if (typeof suffix === 'undefined') var suffix = "";
 
@@ -689,7 +689,7 @@ $.oDrawingColumn.prototype.renameAllByFrame = function(prefix, suffix){
  * Removes unused drawings from the column.
  * @param   {$.oFrame[]}  exposures            The exposures to extend. If UNDEFINED, extends all keyframes.
  */
-$.oDrawingColumn.prototype.removeUnexposedDrawings = function(){
+exports.oDrawingColumn.prototype.removeUnexposedDrawings = function(){
   var _element = this.element;
   var _displayedDrawings = this.getExposedDrawings().map(function(x){return x.value.name;});
   var _element = this.element;
@@ -701,7 +701,7 @@ $.oDrawingColumn.prototype.removeUnexposedDrawings = function(){
   }
 }
 
-$.oDrawingColumn.prototype.getExposedDrawings = function (){
+exports.oDrawingColumn.prototype.getExposedDrawings = function (){
   return this.keyframes.filter(function(x){return x.value != null});
 }
 
@@ -709,6 +709,6 @@ $.oDrawingColumn.prototype.getExposedDrawings = function (){
 /**
  * @private
  */
- $.oDrawingColumn.prototype.toString = function(){
+ exports.oDrawingColumn.prototype.toString = function(){
   return "<$.oDrawingColumn '"+this.name+"'>";
 }

--- a/openHarmony/openHarmony_database.js
+++ b/openHarmony/openHarmony_database.js
@@ -55,7 +55,7 @@
  * A class to access the contents of the Harmony database from a scene.
  * @constructor
  */
-$.oDatabase = function(){
+exports.oDatabase = function(){
 }
 
 
@@ -63,7 +63,7 @@ $.oDatabase = function(){
  * Function to query the database using the dbu utility.
  * @private
  */
-$.oDatabase.prototype.query = function(args){
+exports.oDatabase.prototype.query = function(args){
 	var dbbin = specialFolders.bin+"/dbu";
 	var p = new $.oProcess(dbbin, args);
 	var result = p.execute();
@@ -77,7 +77,7 @@ $.oDatabase.prototype.query = function(args){
  * Lists the environments existing on the local database
  * @return {string[]}  The list of names of environments
  */
-$.oDatabase.prototype.getEnvironments = function(){
+exports.oDatabase.prototype.getEnvironments = function(){
   var dbFile = new this.$.oFile("/USA_DB/envs/env.db");
   if (!dbFile.exists){
     this.$.debug("Can't access Harmony Database at address : /USA_DB/envs/env.db", this.$.DEBUG_LEVEL.ERROR);
@@ -94,7 +94,7 @@ $.oDatabase.prototype.getEnvironments = function(){
  * @param {string}  [environment]    The name of the environment to return the jobs from. Returns the jobs from the current environment by default. 
  * @return {string[]}  The list of job names in the environment.
  */
-$.oDatabase.prototype.getJobs = function(environment){
+exports.oDatabase.prototype.getJobs = function(environment){
   if (typeof environment === 'undefined' && this.$.scene.online) {
     var environment = this.$.scene.environment;
   }else{
@@ -117,7 +117,7 @@ $.oDatabase.prototype.getJobs = function(environment){
  * @param {string}  [job]    The name of the jobs to return the scenes from. Returns the scenes from the current job by default. 
  * @return {string[]}  The list of scene names in the job.
  */
-$.oDatabase.prototype.getScenes = function(job){
+exports.oDatabase.prototype.getScenes = function(job){
   if (typeof job === 'undefined' && this.$.scene.online){
     var job = this.$.scene.job;
   }else{

--- a/openHarmony/openHarmony_database.js
+++ b/openHarmony/openHarmony_database.js
@@ -65,7 +65,7 @@ exports.oDatabase = function(){
  */
 exports.oDatabase.prototype.query = function(args){
 	var dbbin = specialFolders.bin+"/dbu";
-	var p = new $.oProcess(dbbin, args);
+	var p = new this.$.oProcess(dbbin, args);
 	var result = p.execute();
 
 	result = result.split("Name:").join("").split("\r\n");

--- a/openHarmony/openHarmony_dialog.js
+++ b/openHarmony/openHarmony_dialog.js
@@ -1103,7 +1103,7 @@ exports.oPieMenu.prototype.getMenuRadius = function(){
  * @property    {string}              extraRadius              using a set radius between each submenu levels
  * @property    {$.oPieMenu}          parentMenu               the parent menu for this subMenu. Set during initialisation of the menu.
  */
-$.oPieSubMenu = function(name, widgets) {
+exports.oPieSubMenu = function(name, widgets) {
   this.menuIcon = specialFolders.resource + "/icons/toolbar/menu.svg";
   this.closeIcon = specialFolders.resource + "/icons/toolbar/collapseopen.png";
 
@@ -1117,13 +1117,13 @@ $.oPieSubMenu = function(name, widgets) {
 
   this.focusOutEvent = function(){} // delete focusOutEvent response from submenu
 }
-$.oPieSubMenu.prototype = Object.create(exports.oPieMenu.prototype)
+exports.oPieSubMenu.prototype = Object.create(exports.oPieMenu.prototype)
 
 
 /**
  * function called when main button is clicked
  */
-$.oPieSubMenu.prototype.deactivate = function(){
+exports.oPieSubMenu.prototype.deactivate = function(){
   this.showMenu(false);
 }
 
@@ -1132,7 +1132,7 @@ $.oPieSubMenu.prototype.deactivate = function(){
  * @name $.oPieSubMenu#anchor
  * @type {$.oPoint}
  */
-Object.defineProperty($.oPieSubMenu.prototype, "anchor", {
+Object.defineProperty(exports.oPieSubMenu.prototype, "anchor", {
   get: function(){
     var center = this.parentMenu.globalCenter;
     return center.add(-this.widgetSize/2, -this.widgetSize/2);
@@ -1145,7 +1145,7 @@ Object.defineProperty($.oPieSubMenu.prototype, "anchor", {
  * @name $.oPieSubMenu#minRadius
  * @type {int}
  */
-Object.defineProperty($.oPieSubMenu.prototype, "minRadius", {
+Object.defineProperty(exports.oPieSubMenu.prototype, "minRadius", {
   get: function(){
     return this.parentMenu.maxRadius;
   }
@@ -1157,7 +1157,7 @@ Object.defineProperty($.oPieSubMenu.prototype, "minRadius", {
  * @name $.oPieSubMenu#maxRadius
  * @type {int}
  */
-Object.defineProperty($.oPieSubMenu.prototype, "maxRadius", {
+Object.defineProperty(exports.oPieSubMenu.prototype, "maxRadius", {
   get: function(){
     return this.minRadius + this.extraRadius;
   }
@@ -1168,7 +1168,7 @@ Object.defineProperty($.oPieSubMenu.prototype, "maxRadius", {
  * activate the menu button when activate() is called on the menu
  * @private
  */
-$.oPieSubMenu.prototype.activate = function(){
+exports.oPieSubMenu.prototype.activate = function(){
   this.showMenu(true);
   this.setFocus(true)
 }
@@ -1182,7 +1182,7 @@ $.oPieSubMenu.prototype.activate = function(){
  * @param  {int}      y     The x coordinate for the button relative to the piewidget
  * @private
  */
-$.oPieSubMenu.prototype.move = function(x, y){
+exports.oPieSubMenu.prototype.move = function(x, y){
   // move the actual widget to its anchor, but move the button instead
   QWidget.prototype.move.call(this, this.anchor.x, this.anchor.y);
 
@@ -1204,7 +1204,7 @@ $.oPieSubMenu.prototype.move = function(x, y){
  * where calling parent() returns a QWidget and not a $.oPieButton
  * @private
  */
-$.oPieSubMenu.prototype.setParent = function(parent){
+exports.oPieSubMenu.prototype.setParent = function(parent){
   exports.oPieMenu.prototype.setParent.call(this, parent);
   this.parentMenu = parent;
 }
@@ -1215,7 +1215,7 @@ $.oPieSubMenu.prototype.setParent = function(parent){
  * @private
  * @returns {$.oPieButton}
  */
-$.oPieSubMenu.prototype.buildButton = function(){
+exports.oPieSubMenu.prototype.buildButton = function(){
   // add main button in constructor because it needs to exist before show()
   var button = new this.$.oPieButton(this.menuIcon, this.name, this);
   button.activate = function(){}; // prevent the button from closing the entire pie menu 
@@ -1229,7 +1229,7 @@ $.oPieSubMenu.prototype.buildButton = function(){
  * Shows or hides the menu itself (not the button)
  * @param {*} visibility
  */
-$.oPieSubMenu.prototype.showMenu = function(visibility){
+exports.oPieSubMenu.prototype.showMenu = function(visibility){
   for (var i in this.widgets){
     this.widgets[i].visible = visibility;
   }
@@ -1243,7 +1243,7 @@ $.oPieSubMenu.prototype.showMenu = function(visibility){
 /**
  * toggles the display of the menu
  */
-$.oPieSubMenu.prototype.toggleMenu = function(){
+exports.oPieSubMenu.prototype.toggleMenu = function(){
   this.showMenu(!this.slice.visible);
 }
 
@@ -1251,7 +1251,7 @@ $.oPieSubMenu.prototype.toggleMenu = function(){
  * Function to initialise the widgets for the submenu
  * @private
  */
-$.oPieSubMenu.prototype.buildWidget = function(){
+exports.oPieSubMenu.prototype.buildWidget = function(){
   if (!this.parentMenu){
     throw new Error("must set parent first before calling $.oPieMenu.buildWidget()")
   }

--- a/openHarmony/openHarmony_dialog.js
+++ b/openHarmony/openHarmony_dialog.js
@@ -56,7 +56,7 @@
  * $.oDialog Base Class -- helper class for showing GUI content.
  * @constructor
  */
-$.oDialog = function( ){
+exports.oDialog = function( ){
 }
 
 
@@ -72,7 +72,7 @@ $.oDialog = function( ){
  * @return  {bool}       Result of the confirmation dialog.
  */
 
-$.oDialog.prototype.confirm = function( labelText, title, okButtonText, cancelButtonText ){
+exports.oDialog.prototype.confirm = function( labelText, title, okButtonText, cancelButtonText ){
   if (this.$.batchMode) {
     this.$.debug("$.oDialog.confirm not supported in batch mode", this.$.DEBUG_LEVEL.WARNING)
     return;
@@ -110,7 +110,7 @@ $.oDialog.prototype.confirm = function( labelText, title, okButtonText, cancelBu
  * @param   {string}           [okButtonText]                 The text on the OK button of the dialog.
  *
  */
-$.oDialog.prototype.alert = function( labelText, title, okButtonText ){
+exports.oDialog.prototype.alert = function( labelText, title, okButtonText ){
   if (this.$.batchMode) {
     this.$.debug("$.oDialog.alert not supported in batch mode", this.$.DEBUG_LEVEL.WARNING)
     return;
@@ -144,7 +144,7 @@ $.oDialog.prototype.alert = function( labelText, title, okButtonText ){
  * @param   {string}           [okButtonText="OK"]            The text on the OK button of the dialog.
  * @param   {bool}             [htmlSupport=false]
  */
-$.oDialog.prototype.alertBox = function( labelText, title, okButtonText, htmlSupport){
+exports.oDialog.prototype.alertBox = function( labelText, title, okButtonText, htmlSupport){
   if (this.$.batchMode) {
     this.$.debug("$.oDialog.alert not supported in batch mode", this.$.DEBUG_LEVEL.WARNING)
     return;
@@ -186,7 +186,7 @@ $.oDialog.prototype.alertBox = function( labelText, title, okButtonText, htmlSup
  * @param   {float}          [duration=2000]    The duration of the display (in milliseconds).
  * @param   {$.oColorValue}  [color="#000000"]  The color of the background (a 50% alpha value will be applied).
  */
-$.oDialog.prototype.toast = function(labelText, position, duration, color){
+exports.oDialog.prototype.toast = function(labelText, position, duration, color){
   if (this.$.batchMode) {
     this.$.debug("$.oDialog.alert not supported in batch mode", this.$.DEBUG_LEVEL.WARNING);
     return;
@@ -250,7 +250,7 @@ $.oDialog.prototype.toast = function(labelText, position, duration, color){
  * @param   {string}           [prefilledText]                The text to display in the input area.
  *
  */
-$.oDialog.prototype.prompt = function( labelText, title, prefilledText){
+exports.oDialog.prototype.prompt = function( labelText, title, prefilledText){
   if (typeof labelText === 'undefined') var labelText = "enter value :";
   if (typeof title === 'undefined') var title = "Prompt";
   if (typeof prefilledText === 'undefined') var prefilledText = "";
@@ -268,7 +268,7 @@ $.oDialog.prototype.prompt = function( labelText, title, prefilledText){
  *
  * @return  {string[]}         The list of selected Files, 'undefined' if the dialog is cancelled
  */
-$.oDialog.prototype.browseForFile = function( text, filter, getExisting, acceptMultiple, startDirectory){
+exports.oDialog.prototype.browseForFile = function( text, filter, getExisting, acceptMultiple, startDirectory){
   if (this.$.batchMode) {
     this.$.debug("$.oDialog.browseForFile not supported in batch mode", this.$.DEBUG_LEVEL.WARNING)
     return;
@@ -306,7 +306,7 @@ $.oDialog.prototype.browseForFile = function( text, filter, getExisting, acceptM
  *
  * @return  {string}           The path of the selected folder, 'undefined' if the dialog is cancelled
  */
-$.oDialog.prototype.browseForFolder = function(text, startDirectory){
+exports.oDialog.prototype.browseForFolder = function(text, startDirectory){
   if (this.$.batchMode) {
     this.$.debug("$.oDialog.browseForFolder not supported in batch mode", this.$.DEBUG_LEVEL.WARNING)
     return;
@@ -331,7 +331,7 @@ $.oDialog.prototype.browseForFolder = function(text, startDirectory){
  *
  * @return  {oFile[]}           An oFile array, or 'undefined' if the dialog is cancelled
  */
-$.oDialog.prototype.chooseFile = function( text, filter, getExisting, acceptMultiple, startDirectory){
+exports.oDialog.prototype.chooseFile = function( text, filter, getExisting, acceptMultiple, startDirectory){
   if (this.$.batchMode) {
     this.$.debug("$.oDialog.chooseFile not supported in batch mode", this.$.DEBUG_LEVEL.WARNING)
     return;
@@ -376,7 +376,7 @@ $.oDialog.prototype.chooseFile = function( text, filter, getExisting, acceptMult
  *
  * @return  {oFolder}           An oFolder for the selected folder, or undefined if dialog was cancelled
  */
-$.oDialog.prototype.chooseFolder = function(text, startDirectory){
+exports.oDialog.prototype.chooseFolder = function(text, startDirectory){
   if (this.$.batchMode) {
     this.$.debug("$.oDialog.chooseFolder not supported in batch mode", this.$.DEBUG_LEVEL.WARNING)
     return;
@@ -417,7 +417,7 @@ $.oDialog.prototype.chooseFolder = function(text, startDirectory){
  * @property    {bool}                wasCanceled                Whether the progress bar was cancelled.
  * @property    {$.oSignal}           canceled                   A Signal emited when the dialog is canceled. Can be connected to a callback.
  */
-$.oProgressDialog = function( labelText, range, title, show ){
+exports.oProgressDialog = function( labelText, range, title, show ){
   if (typeof title === 'undefined') var title = "Progress";
   if (typeof range === 'undefined') var range = 100;
   if (typeof labelText === 'undefined') var labelText = "";
@@ -445,7 +445,7 @@ $.oProgressDialog = function( labelText, range, title, show ){
 
 
 // legacy compatibility
-$.oDialog.Progress = $.oProgressDialog;
+exports.oDialog.Progress = exports.oProgressDialog;
 
 
 /**
@@ -453,7 +453,7 @@ $.oDialog.Progress = $.oProgressDialog;
  * @name $.oProgressDialog#label
  * @type {string}
  */
-Object.defineProperty( $.oProgressDialog.prototype, 'label', {
+Object.defineProperty( exports.oProgressDialog.prototype, 'label', {
   get: function(){
     return this._labelText;
   },
@@ -469,7 +469,7 @@ Object.defineProperty( $.oProgressDialog.prototype, 'label', {
  * @name $.oProgressDialog#range
  * @type {int}
  */
-Object.defineProperty( $.oProgressDialog.prototype, 'range', {
+Object.defineProperty( exports.oProgressDialog.prototype, 'range', {
     get: function(){
       return this._range;
     },
@@ -485,7 +485,7 @@ Object.defineProperty( $.oProgressDialog.prototype, 'range', {
  * @name $.oProgressDialog#value
  * @type {int}
  */
-Object.defineProperty( $.oProgressDialog.prototype, 'value', {
+Object.defineProperty( exports.oProgressDialog.prototype, 'value', {
     get: function(){
       return this._value;
     },
@@ -509,7 +509,7 @@ Object.defineProperty( $.oProgressDialog.prototype, 'value', {
  * @name $.oProgressDialog#cancelled
  * @deprecated use $.oProgressDialog.wasCanceled to get the cancel status, or connect a function to the "canceled" signal.
  */
-Object.defineProperty( $.oProgressDialog.prototype, 'cancelled', {
+Object.defineProperty( exports.oProgressDialog.prototype, 'cancelled', {
   get: function(){
     return this.wasCanceled;
   }
@@ -521,7 +521,7 @@ Object.defineProperty( $.oProgressDialog.prototype, 'cancelled', {
 /**
  * Shows the dialog.
  */
-$.oProgressDialog.prototype.show = function(){
+exports.oProgressDialog.prototype.show = function(){
   if (this.$.batchMode) {
     this.$.debug("$.oProgressDialog not supported in batch mode", this.$.DEBUG_LEVEL.ERROR)
     return;
@@ -533,7 +533,7 @@ $.oProgressDialog.prototype.show = function(){
 /**
  * Closes the dialog.
  */
-$.oProgressDialog.prototype.close = function(){
+exports.oProgressDialog.prototype.close = function(){
   this.value = this.range;
   this.$.log("Progress : "+this.value+"/"+this._range)
 
@@ -658,7 +658,7 @@ function openMenu(){
   // we show it!
   menu.show();
 }*/
-$.oPieMenu = function( name, widgets, show, minAngle, maxAngle, radius, position, parent){
+exports.oPieMenu = function( name, widgets, show, minAngle, maxAngle, radius, position, parent){
   this.name = name;
   this.widgets = widgets;
 
@@ -717,13 +717,13 @@ $.oPieMenu = function( name, widgets, show, minAngle, maxAngle, radius, position
 
   if (show) this.show();
 }
-$.oPieMenu.prototype = Object.create(QWidget.prototype);
+exports.oPieMenu.prototype = Object.create(QWidget.prototype);
 
 
 /**
  * function run when the menu button is clicked
  */
-$.oPieMenu.prototype.deactivate = function(){
+exports.oPieMenu.prototype.deactivate = function(){
   this.closeMenu()
 }
 
@@ -731,7 +731,7 @@ $.oPieMenu.prototype.deactivate = function(){
  * Closes the menu and all its subWidgets
  * @private
  */
-$.oPieMenu.prototype.closeMenu = function(){
+exports.oPieMenu.prototype.closeMenu = function(){
   for (var i in this.widgets){
     this.widgets[i].close()
   }
@@ -743,7 +743,7 @@ $.oPieMenu.prototype.closeMenu = function(){
  * @name $.oPieMenu#anchor
  * @type {$.oPoint}
  */
-Object.defineProperty($.oPieMenu.prototype, "anchor", {
+Object.defineProperty(exports.oPieMenu.prototype, "anchor", {
   get: function(){
     var point = this.globalCenter.add(-this.center.x, -this.center.y);
     return point;
@@ -756,7 +756,7 @@ Object.defineProperty($.oPieMenu.prototype, "anchor", {
  * @name $.oPieMenu#center
  * @type {$.oPoint}
  */
-Object.defineProperty($.oPieMenu.prototype, "center", {
+Object.defineProperty(exports.oPieMenu.prototype, "center", {
   get: function(){
     return new this.$.oPoint(this.widgetSize/2, this.widgetSize/2)
   }
@@ -768,7 +768,7 @@ Object.defineProperty($.oPieMenu.prototype, "center", {
  * @name $.oPieMenu#minRadius
  * @type {int}
  */
-Object.defineProperty($.oPieMenu.prototype, "minRadius", {
+Object.defineProperty(exports.oPieMenu.prototype, "minRadius", {
   get: function(){
     return this._circleMargin;
   }
@@ -780,7 +780,7 @@ Object.defineProperty($.oPieMenu.prototype, "minRadius", {
  * @name $.oPieMenu#maxRadius
  * @type {int}
  */
-Object.defineProperty($.oPieMenu.prototype, "maxRadius", {
+Object.defineProperty(exports.oPieMenu.prototype, "maxRadius", {
   get: function(){
     return this.radius + this._circleMargin;
   }
@@ -791,7 +791,7 @@ Object.defineProperty($.oPieMenu.prototype, "maxRadius", {
  * @name $.oPieMenu#widgetSize
  * @type {int}
  */
- Object.defineProperty($.oPieMenu.prototype, "widgetSize", {
+ Object.defineProperty(exports.oPieMenu.prototype, "widgetSize", {
   get: function(){
     return this.maxRadius*4;
   }
@@ -802,7 +802,7 @@ Object.defineProperty($.oPieMenu.prototype, "maxRadius", {
  * Builds the menu's main button.
  * @returns {$.oPieButton}
  */
-$.oPieMenu.prototype.buildButton = function(){
+exports.oPieMenu.prototype.buildButton = function(){
   // add main button in constructor because it needs to exist before show()
   var icon = specialFolders.resource + "/icons/brushpreset/defaultpresetellipse/ellipse03.svg"
   button = new this.$.oPieButton(icon, "", this);
@@ -816,7 +816,7 @@ $.oPieMenu.prototype.buildButton = function(){
  * Build and show the pie menu and its widgets.
  * @private
  */
-$.oPieMenu.prototype.buildWidget = function(){
+exports.oPieMenu.prototype.buildWidget = function(){
   // match the widget geometry with the main window/parent
   var anchor = this.anchor
   this.move(anchor.x, anchor.y);
@@ -863,7 +863,7 @@ $.oPieMenu.prototype.buildWidget = function(){
  * @param {int}   [minRadius]      specify a minimum radius for the slice
  * @private
  */
-$.oPieMenu.prototype.drawSlice = function(){
+exports.oPieMenu.prototype.drawSlice = function(){
   var index = 0;
 
   // get the slice and background geometry
@@ -978,7 +978,7 @@ $.oPieMenu.prototype.drawSlice = function(){
  * @param {float}       maxRadius   the largest circle radius
  * @private
  */
-$.oPieMenu.prototype.getSlicePath = function(center, minAngle, maxAngle, minRadius, maxRadius){
+exports.oPieMenu.prototype.getSlicePath = function(center, minAngle, maxAngle, minRadius, maxRadius){
   // work out the geometry
   var smallArcBoundingBox = new QRectF(center.x-minRadius, center.y-minRadius, minRadius*2, minRadius*2);
   var smallArcStart = new this.$.oPoint();
@@ -1007,7 +1007,7 @@ $.oPieMenu.prototype.getSlicePath = function(center, minAngle, maxAngle, minRadi
  * @param {int}     index         the index of the widget
  * @return {float[]}
  */
-$.oPieMenu.prototype.getItemAngleRange = function(index){
+exports.oPieMenu.prototype.getItemAngleRange = function(index){
   var length = this.widgets.length;
   var angleStart = this.minAngle+(index/length)*(this.maxAngle-this.minAngle);
   var angleEnd = this.minAngle+((index+1)/length)*(this.maxAngle-this.minAngle);
@@ -1021,7 +1021,7 @@ $.oPieMenu.prototype.getItemAngleRange = function(index){
  * @param {int}     index         the index of the widget
  * @return {float}
  */
-$.oPieMenu.prototype.getItemAngle = function(index){
+exports.oPieMenu.prototype.getItemAngle = function(index){
   var angleRange = this.getItemAngleRange(index, this.minAngle, this.maxAngle);
   var angle = (angleRange[1] - angleRange[0])/2+angleRange[0]
 
@@ -1035,7 +1035,7 @@ $.oPieMenu.prototype.getItemAngle = function(index){
  * @param {float}     angle         the index of the widget
  * @return {float}
  */
-$.oPieMenu.prototype.getIndexAtAngle = function(angle){
+exports.oPieMenu.prototype.getIndexAtAngle = function(angle){
   var angleRange = (this.maxAngle-this.minAngle)/this.widgets.length
   return Math.floor((angle-this.minAngle)/angleRange);
 }
@@ -1047,7 +1047,7 @@ $.oPieMenu.prototype.getIndexAtAngle = function(angle){
  * @param {int}     index         the index of the widget
  * @return {$.oPoint}
  */
-$.oPieMenu.prototype.getItemPosition = function(index){
+exports.oPieMenu.prototype.getItemPosition = function(index){
   // we add pi to the angle because of the inverted Y axis of widgets coordinates
   var pi = Math.PI;
   var angle = this.getItemAngle(index, this.minAngle, this.maxAngle)*(-pi);
@@ -1063,7 +1063,7 @@ $.oPieMenu.prototype.getItemPosition = function(index){
  * @private
  * @return {float}
  */
-$.oPieMenu.prototype.getMenuRadius = function(){
+exports.oPieMenu.prototype.getMenuRadius = function(){
   var itemsNumber = this.widgets.length
   var _maxRadius = UiLoader.dpiScale(200);
   var _minRadius = UiLoader.dpiScale(30);
@@ -1117,7 +1117,7 @@ $.oPieSubMenu = function(name, widgets) {
 
   this.focusOutEvent = function(){} // delete focusOutEvent response from submenu
 }
-$.oPieSubMenu.prototype = Object.create($.oPieMenu.prototype)
+$.oPieSubMenu.prototype = Object.create(exports.oPieMenu.prototype)
 
 
 /**
@@ -1205,7 +1205,7 @@ $.oPieSubMenu.prototype.move = function(x, y){
  * @private
  */
 $.oPieSubMenu.prototype.setParent = function(parent){
-  $.oPieMenu.prototype.setParent.call(this, parent);
+  exports.oPieMenu.prototype.setParent.call(this, parent);
   this.parentMenu = parent;
 }
 
@@ -1267,7 +1267,7 @@ $.oPieSubMenu.prototype.buildWidget = function(){
   this.minAngle = angle-widgetNum*this.itemAngle;
   this.maxAngle = angle+widgetNum*this.itemAngle;
 
-  $.oPieMenu.prototype.buildWidget.call(this);
+  exports.oPieMenu.prototype.buildWidget.call(this);
 
   this.showMenu(false)
 }
@@ -1296,7 +1296,7 @@ $.oPieSubMenu.prototype.buildWidget = function(){
  * @param {QWidget}  parent                 The parent QWidget for the button. Automatically set during initialisation of the menu.
  *
  */
- $.oPieButton = function(iconFile, text, parent) {
+ exports.oPieButton = function(iconFile, text, parent) {
   // if icon isnt provided
   if (typeof parent === 'undefined') var parent = $.app.mainWindow
   if (typeof text === 'undefined') var text = ""
@@ -1328,13 +1328,13 @@ $.oPieSubMenu.prototype.buildWidget = function(){
   var button = this;
   this.clicked.connect(function(){button.activate()})
 }
-$.oPieButton.prototype = Object.create(QPushButton.prototype);
+exports.oPieButton.prototype = Object.create(QPushButton.prototype);
 
 
 /**
  * Closes the parent menu of the button and all its subWidgets.
  */
-$.oPieButton.prototype.closeMenu = function(){
+exports.oPieButton.prototype.closeMenu = function(){
   var menu = this.parentMenu;
   while (menu && menu.parentMenu){
     menu = menu.parentMenu;
@@ -1345,7 +1345,7 @@ $.oPieButton.prototype.closeMenu = function(){
 /**
  * Reimplement this function in order to activate the button and also close the menu.
  */
-$.oPieButton.prototype.activate = function(){
+exports.oPieButton.prototype.activate = function(){
   // reimplement to change the behavior when the button is activated.
   // by default, will just close the menu.
   this.closeMenu();
@@ -1358,7 +1358,7 @@ $.oPieButton.prototype.activate = function(){
  * where calling parent() returns a QWidget and not a $.oPieButton
  * @private
  */
-$.oPieButton.prototype.setParent = function(parent){
+exports.oPieButton.prototype.setParent = function(parent){
   QPushButton.prototype.setParent.call(this, parent);
   this.parentMenu = parent;
 }
@@ -1386,7 +1386,7 @@ $.oPieButton.prototype.setParent = function(parent){
  * @param {QWidget}  parent                   The parent QWidget for the button. Automatically set during initialisation of the menu.
  *
  */
- $.oToolButton = function(toolName, showName, iconFile, parent) {
+ exports.oToolButton = function(toolName, showName, iconFile, parent) {
   this.toolName = toolName;
   if (typeof showName === "undefined") var showName = false;
 
@@ -1412,10 +1412,10 @@ $.oPieButton.prototype.setParent = function(parent){
 
   this.toolTip = this.toolName;
 }
-$.oToolButton.prototype = Object.create($.oPieButton.prototype);
+exports.oToolButton.prototype = Object.create(exports.oPieButton.prototype);
 
 
-$.oToolButton.prototype.activate = function(){
+exports.oToolButton.prototype.activate = function(){
   this.$.app.currentTool = this.toolName;
   this.closeMenu()
 }
@@ -1443,7 +1443,7 @@ $.oToolButton.prototype.activate = function(){
  * @param {string}   iconFile                 An icon path for the button.
  * @param {QWidget}  parent                   The parent QWidget for the button. Automatically set during initialisation of the menu.
  */
- $.oActionButton = function(actionName, responder, text, iconFile, parent) {
+exports.oActionButton = function(actionName, responder, text, iconFile, parent) {
   this.action = actionName;
   this.responder = responder;
 
@@ -1454,10 +1454,10 @@ $.oToolButton.prototype.activate = function(){
   this.$.oPieButton.call(this, iconFile, text, parent);
   this.toolTip = this.toolName;
 }
-$.oActionButton.prototype = Object.create($.oPieButton.prototype);
+exports.oActionButton.prototype = Object.create(exports.oPieButton.prototype);
 
 
-$.oActionButton.prototype.activate = function(){
+exports.oActionButton.prototype.activate = function(){
   if (this.responder){
     // log("Validating : "+ this.actionName + " ? "+ Action.validate(this.actionName, this.responder).enabled)
     if (Action.validate(this.action, this.responder).enabled){
@@ -1496,7 +1496,7 @@ $.oActionButton.prototype.activate = function(){
  * @param {QWidget}  parent                   The parent QWidget for the button. Automatically set during initialisation of the menu.
  *
  */
- $.oColorButton = function(paletteName, colorName, showName, parent) {
+ exports.oColorButton = function(paletteName, colorName, showName, parent) {
   this.paletteName = paletteName;
   this.colorName = colorName;
 
@@ -1516,10 +1516,10 @@ $.oActionButton.prototype.activate = function(){
 
   this.toolTip = this.paletteName + ": " + this.colorName;
 }
-$.oColorButton.prototype = Object.create($.oPieButton.prototype);
+exports.oColorButton.prototype = Object.create(exports.oPieButton.prototype);
 
 
-$.oColorButton.prototype.activate = function(){
+exports.oColorButton.prototype.activate = function(){
   var palette = this.$.scn.getPaletteByName(this.paletteName);
   var color = palette.getColorByName(this.colorName);
 
@@ -1553,7 +1553,7 @@ $.oColorButton.prototype.activate = function(){
  * @param {string}   scriptFunction           The function name to launch from the script
  * @param {QWidget}  parent                   The parent QWidget for the button. Automatically set during initialisation of the menu.
  */
-$.oScriptButton = function(scriptFile, scriptFunction, parent) {
+exports.oScriptButton = function(scriptFile, scriptFunction, parent) {
   this.scriptFile = scriptFile;
   this.scriptFunction = scriptFunction;
 
@@ -1579,9 +1579,9 @@ $.oScriptButton = function(scriptFile, scriptFunction, parent) {
 
   this.toolTip = this.scriptFunction;
 }
-$.oScriptButton.prototype = Object.create($.oPieButton.prototype);
+exports.oScriptButton.prototype = Object.create(exports.oPieButton.prototype);
 
-$.oScriptButton.prototype.activate = function(){
+exports.oScriptButton.prototype.activate = function(){
   include(this.scriptFile);
   eval(this.scriptFunction)();
   this.closeMenu()
@@ -1609,7 +1609,7 @@ $.oScriptButton.prototype.activate = function(){
  * @param {string}   iconFile                 An icon path for the button.
  * @param {QWidget}  parent                   The parent QWidget for the button. Automatically set during initialisation of the menu.
  */
-$.oPrefButton = function(preferenceString, text, iconFile, parent) {
+exports.oPrefButton = function(preferenceString, text, iconFile, parent) {
   this.preferenceString = preferenceString;
 
   if (typeof iconFile === 'undefined') var iconFile = specialFolders.resource+"/icons/toolproperties/settings.svg";
@@ -1620,10 +1620,10 @@ $.oPrefButton = function(preferenceString, text, iconFile, parent) {
 
   this.toolTip = this.preferenceString;
 }
-$.oPrefButton.prototype = Object.create($.oPieButton.prototype);
+exports.oPrefButton.prototype = Object.create(exports.oPieButton.prototype);
 
 
-$.oPrefButton.prototype.activate = function(){
+exports.oPrefButton.prototype.activate = function(){
   var value = preferences.getBool(this.preferenceString, true);
   this.checked != value;
   preferences.setBool(this.preferenceString, value);
@@ -1642,7 +1642,7 @@ $.oPrefButton.prototype.activate = function(){
 
 
 // not currently working
-$.oStencilButton = function(stencilName, parent) {
+exports.oStencilButton = function(stencilName, parent) {
   this.stencilName = stencilName;
 
   var iconFile = specialFolders.resource+"/icons/brushpreset/default.svg";
@@ -1651,9 +1651,9 @@ $.oStencilButton = function(stencilName, parent) {
 
   this.toolTip = stencilName;
 }
-$.oStencilButton.prototype = Object.create($.oPieButton.prototype);
+exports.oStencilButton.prototype = Object.create(exports.oPieButton.prototype);
 
-$.oStencilButton.prototype.activate = function(){
+exports.oStencilButton.prototype.activate = function(){
   this.$.app.currentStencil = this.stencilName;
 
   this.closeMenu()

--- a/openHarmony/openHarmony_dialog.js
+++ b/openHarmony/openHarmony_dialog.js
@@ -193,14 +193,14 @@ exports.oDialog.prototype.toast = function(labelText, position, duration, color)
   }
 
   if (typeof duration === 'undefined') var duration = 2000;
-  if (typeof color === 'undefined') var color = new $.oColorValue(0,0,0);
+  if (typeof color === 'undefined') var color = new this.$.oColorValue(0,0,0);
   
   var toast = new QWidget()
   if (this.$.app.version + this.$.app.minorVersion > 21){
     // above Harmony 21.1
     if (typeof position === 'undefined'){
       var center = QApplication.desktop().availableGeometry.center();
-      var position = new $.oPoint(center.x(), center.y()+UiLoader.dpiScale(150))
+      var position = new this.$.oPoint(center.x(), center.y()+UiLoader.dpiScale(150))
     }
     var flags = new Qt.WindowFlags(Qt.Tool|Qt.FramelessWindowHint); // https://qtcentre.org/threads/71912-Qt-WA_TransparentForMouseEvents
     toast.setWindowFlags(flags);
@@ -208,7 +208,7 @@ exports.oDialog.prototype.toast = function(labelText, position, duration, color)
   } else {
     if (typeof position === 'undefined'){
       var center = QApplication.desktop().screen().rect.center();
-      var position = new $.oPoint(center.x(), center.y()+UiLoader.dpiScale(150))
+      var position = new this.$.oPoint(center.x(), center.y()+UiLoader.dpiScale(150))
     }
     var flags = new Qt.WindowFlags(Qt.Popup|Qt.FramelessWindowHint|Qt.WA_TransparentForMouseEvents);
     toast.setWindowFlags(flags);
@@ -358,10 +358,10 @@ exports.oDialog.prototype.chooseFile = function( text, filter, getExisting, acce
   if (!_chosen.length) return undefined;
 
   try {
-    _chosen = _chosen.map(function(thisFile){return new $.oFile(thisFile);});
+    _chosen = _chosen.map(function(thisFile){return new this.$.oFile(thisFile);});
   } catch (err) {
     // No "map" method means not an array
-    _chosen = [new $.oFile(_chosen)];
+    _chosen = [new this.$.oFile(_chosen)];
   }
 
   this.$.debug(_chosen);
@@ -388,7 +388,7 @@ exports.oDialog.prototype.chooseFolder = function(text, startDirectory){
 
   if (!_folder) return undefined; // User cancelled
 
-  return new $.oFolder(_folder);
+  return new this.$.oFolder(_folder);
 }
 
 //////////////////////////////////////
@@ -1316,7 +1316,7 @@ $.oPieSubMenu.prototype.buildWidget = function(){
     UiLoader.setSvgIcon(this, iconFile)
     this.setIconSize(new QSize(this.minimumWidth, this.minimumHeight));
   }catch(e){
-    $.log("failed to load icon "+iconFile)
+    this.$.log("failed to load icon "+iconFile)
   }
   this.cursor = new QCursor(Qt.PointingHandCursor);
 
@@ -1396,7 +1396,7 @@ exports.oPieButton.prototype.setParent = function(parent){
     try{
       var iconFiles = scriptIconsFolder.getFiles(toolName.replace(" ", "").toLowerCase() + ".*");
     }catch(e){
-      $.log("error was caught " + e);
+      this.$.log("error was caught " + e);
       var iconFiles = [];
     }
 
@@ -1459,7 +1459,7 @@ exports.oActionButton.prototype = Object.create(exports.oPieButton.prototype);
 
 exports.oActionButton.prototype.activate = function(){
   if (this.responder){
-    // log("Validating : "+ this.actionName + " ? "+ Action.validate(this.actionName, this.responder).enabled)
+    // this.$.log("Validating : "+ this.actionName + " ? "+ Action.validate(this.actionName, this.responder).enabled)
     if (Action.validate(this.action, this.responder).enabled){
       Action.perform(this.action, this.responder);
     }
@@ -1563,7 +1563,7 @@ exports.oScriptButton = function(scriptFile, scriptFunction, parent) {
   try{
     var iconFiles = scriptIconsFolder.getFiles(scriptFunction+".*");
   } catch(e){
-    $.log("error was caught " + e);
+    this.$.log("error was caught " + e);
     var iconFiles = [];
   }
 

--- a/openHarmony/openHarmony_drawing.js
+++ b/openHarmony/openHarmony_drawing.js
@@ -59,7 +59,8 @@
  * @property {int}                   name                       The name of the drawing.
  * @property {$.oElement}            element                    The element object associated to the element.
  */
-$.oDrawing = function (name, synchedLayer, oElementObject) {
+
+exports.oDrawing = function (name, synchedLayer, oElementObject) {
   this._type = "drawing";
   this._name = name;
   this.element = oElementObject;
@@ -90,7 +91,7 @@ $.oDrawing = function (name, synchedLayer, oElementObject) {
  * @name $.oDrawing#LINE_END_TYPE
  * @enum
  */
-$.oDrawing.LINE_END_TYPE = {
+exports.oDrawing.LINE_END_TYPE = {
   ROUND: 1,
   FLAT: 2,
   BEVEL: 3
@@ -102,7 +103,7 @@ $.oDrawing.LINE_END_TYPE = {
  * @name $.oDrawing#ART_LAYER
  * @enum
  */
-$.oDrawing.ART_LAYER = {
+exports.oDrawing.ART_LAYER = {
   OVERLAY: 8,
   LINEART: 4,
   COLORART: 2,
@@ -115,7 +116,7 @@ $.oDrawing.ART_LAYER = {
  * @name $.oDrawing#name
  * @type {string}
  */
-Object.defineProperty($.oDrawing.prototype, 'name', {
+Object.defineProperty(exports.oDrawing.prototype, 'name', {
   get: function () {
     return this._name;
   },
@@ -139,7 +140,7 @@ Object.defineProperty($.oDrawing.prototype, 'name', {
  * @readonly
  * @type {int}
  */
-Object.defineProperty($.oDrawing.prototype, 'id', {
+Object.defineProperty(exports.oDrawing.prototype, 'id', {
   get: function () {
     return this._key.drawingId;
   }
@@ -152,7 +153,7 @@ Object.defineProperty($.oDrawing.prototype, 'id', {
  * @readonly
  * @type {string}
  */
-Object.defineProperty($.oDrawing.prototype, 'path', {
+Object.defineProperty(exports.oDrawing.prototype, 'path', {
   get: function () {
     var _file = new this.$.oFile(Drawing.filename(this.element.id, this.name));
     if (this._key.layer){
@@ -169,7 +170,7 @@ Object.defineProperty($.oDrawing.prototype, 'path', {
  * @name $.oDrawing#pivot
  * @type {$.oPoint}
  */
-Object.defineProperty($.oDrawing.prototype, 'pivot', {
+Object.defineProperty(exports.oDrawing.prototype, 'pivot', {
   get: function () {
     if (this.$.batchMode){
       throw new Error("oDrawing.pivot is not available in batch mode.")
@@ -191,7 +192,7 @@ Object.defineProperty($.oDrawing.prototype, 'pivot', {
  * @name $.oDrawing#usedColorIds
  * @type {string[]}
  */
-Object.defineProperty($.oDrawing.prototype, 'usedColorIds', {
+Object.defineProperty(exports.oDrawing.prototype, 'usedColorIds', {
   get: function () {
     var _colorIds = DrawingTools.getDrawingUsedColors(this._key);
     return _colorIds;
@@ -205,7 +206,7 @@ Object.defineProperty($.oDrawing.prototype, 'usedColorIds', {
  * @readonly
  * @type {$.oBox}
  */
-Object.defineProperty($.oDrawing.prototype, 'boundingBox', {
+Object.defineProperty(exports.oDrawing.prototype, 'boundingBox', {
   get: function () {
     if (this.$.batchMode){
       throw new Error("oDrawing.boudingBox is not available in batch mode.")
@@ -228,7 +229,7 @@ Object.defineProperty($.oDrawing.prototype, 'boundingBox', {
  * @readonly
  * @type {$.oArtLayer}
  */
-Object.defineProperty($.oDrawing.prototype, 'underlay', {
+Object.defineProperty(exports.oDrawing.prototype, 'underlay', {
   get: function () {
     return this._underlay;
   }
@@ -241,7 +242,7 @@ Object.defineProperty($.oDrawing.prototype, 'underlay', {
  * @readonly
  * @type {$.oArtLayer}
  */
-Object.defineProperty($.oDrawing.prototype, 'colorArt', {
+Object.defineProperty(exports.oDrawing.prototype, 'colorArt', {
   get: function () {
     return this._colorArt;
   }
@@ -254,7 +255,7 @@ Object.defineProperty($.oDrawing.prototype, 'colorArt', {
  * @readonly
  * @type {$.oArtLayer}
  */
-Object.defineProperty($.oDrawing.prototype, 'lineArt', {
+Object.defineProperty(exports.oDrawing.prototype, 'lineArt', {
   get: function () {
     return this._lineArt;
   }
@@ -267,7 +268,7 @@ Object.defineProperty($.oDrawing.prototype, 'lineArt', {
  * @readonly
  * @type {$.oArtLayer}
  */
-Object.defineProperty($.oDrawing.prototype, 'overlay', {
+Object.defineProperty(exports.oDrawing.prototype, 'overlay', {
   get: function () {
     return this._overlay;
   }
@@ -280,7 +281,7 @@ Object.defineProperty($.oDrawing.prototype, 'overlay', {
  * @readonly
  * @type {$.oArtLayer[]}
  */
-Object.defineProperty($.oDrawing.prototype, 'artLayers', {
+Object.defineProperty(exports.oDrawing.prototype, 'artLayers', {
   get: function () {
     return this._artLayers;
   }
@@ -294,7 +295,7 @@ Object.defineProperty($.oDrawing.prototype, 'artLayers', {
  * @readonly
  * @type {$.oShape[]}
  */
-Object.defineProperty($.oDrawing.prototype, 'shapes', {
+Object.defineProperty(exports.oDrawing.prototype, 'shapes', {
   get: function () {
     var _shapes = [];
     for (var i in this.artLayers) {
@@ -312,7 +313,7 @@ Object.defineProperty($.oDrawing.prototype, 'shapes', {
  * @readonly
  * @type {$.oStroke[]}
  */
-Object.defineProperty($.oDrawing.prototype, 'strokes', {
+Object.defineProperty(exports.oDrawing.prototype, 'strokes', {
   get: function () {
     var _strokes = [];
     for (var i in this.artLayers) {
@@ -329,7 +330,7 @@ Object.defineProperty($.oDrawing.prototype, 'strokes', {
  * @name $.oDrawing#contours
  * @type {$.oContour[]}
  */
- Object.defineProperty($.oDrawing.prototype, 'contours', {
+ Object.defineProperty(exports.oDrawing.prototype, 'contours', {
   get: function () {
     var _contours = []
 
@@ -348,7 +349,7 @@ Object.defineProperty($.oDrawing.prototype, 'strokes', {
  * @name $.oDrawing#activeArtLayer
  * @type {$.oArtLayer}
  */
-Object.defineProperty($.oDrawing.prototype, 'activeArtLayer', {
+Object.defineProperty(exports.oDrawing.prototype, 'activeArtLayer', {
   get: function () {
     var settings = Tools.getToolSettings();
     if (!settings.currentDrawing) return null;
@@ -368,7 +369,7 @@ Object.defineProperty($.oDrawing.prototype, 'activeArtLayer', {
  * @name $.oDrawing#selectedShapes
  * @type {$.oShape}
  */
-Object.defineProperty($.oDrawing.prototype, 'selectedShapes', {
+Object.defineProperty(exports.oDrawing.prototype, 'selectedShapes', {
   get: function () {
     var _selectedShapes = [];
     for (var i in this.artLayers) {
@@ -385,7 +386,7 @@ Object.defineProperty($.oDrawing.prototype, 'selectedShapes', {
  * @name $.oDrawing#selectedStrokes
  * @type {$.oShape}
  */
-Object.defineProperty($.oDrawing.prototype, 'selectedStrokes', {
+Object.defineProperty(exports.oDrawing.prototype, 'selectedStrokes', {
   get: function () {
     var _selectedStrokes = [];
     for (var i in this.artLayers) {
@@ -402,7 +403,7 @@ Object.defineProperty($.oDrawing.prototype, 'selectedStrokes', {
  * @name $.oDrawing#selectedContours
  * @type {$.oShape}
  */
-Object.defineProperty($.oDrawing.prototype, 'selectedContours', {
+Object.defineProperty(exports.oDrawing.prototype, 'selectedContours', {
   get: function () {
     var _selectedContours = [];
     for (var i in this.artLayers) {
@@ -421,7 +422,7 @@ Object.defineProperty($.oDrawing.prototype, 'selectedContours', {
  * @readonly
  * @private
  */
-Object.defineProperty($.oDrawing.prototype, 'drawingData', {
+Object.defineProperty(exports.oDrawing.prototype, 'drawingData', {
   get: function () {
     var _data = Drawing.query.getData({drawing: this._key});
     if (!_data) throw new Error("Data unavailable for drawing "+this.name)
@@ -437,7 +438,7 @@ Object.defineProperty($.oDrawing.prototype, 'drawingData', {
  * @readonly
  * @private
  */
-Object.defineProperty($.oDrawing.prototype, 'synchedDrawings', {
+Object.defineProperty(exports.oDrawing.prototype, 'synchedDrawings', {
   get: function () {
     var _syncedElements = this.element.synchedElements;
     var _syncedDrawings = []
@@ -461,7 +462,7 @@ Object.defineProperty($.oDrawing.prototype, 'synchedDrawings', {
  *
  * @return { $.oFile }   the oFile object pointing to the drawing file after being it has been imported into the element folder.
  */
-$.oDrawing.prototype.importBitmap = function (file, convertToTvg) {
+exports.oDrawing.prototype.importBitmap = function (file, convertToTvg) {
   var _path = new this.$.oFile(this.path);
   if (!(file instanceof this.$.oFile)) file = new this.$.oFile(file);
   if (!file.exists) throw new Error ("Can't import bitmap "+file.path+", file doesn't exist");
@@ -491,7 +492,7 @@ $.oDrawing.prototype.importBitmap = function (file, convertToTvg) {
 /**
  * @returns {int[]}  The frame numbers at which this drawing appears.
  */
-$.oDrawing.prototype.getVisibleFrames = function () {
+exports.oDrawing.prototype.getVisibleFrames = function () {
   var _element = this.element;
   var _column = _element.column;
 
@@ -513,7 +514,7 @@ $.oDrawing.prototype.getVisibleFrames = function () {
 /**
  * Remove the drawing from the element.
  */
-$.oDrawing.prototype.remove = function () {
+exports.oDrawing.prototype.remove = function () {
   var _element = this.element;
   var _column = _element.column;
 
@@ -544,7 +545,7 @@ $.oDrawing.prototype.remove = function () {
 /**
  * refresh the preview of the drawing.
  */
-$.oDrawing.prototype.refreshPreview = function () {
+exports.oDrawing.prototype.refreshPreview = function () {
   if (this.element.format == "TVG") return;
 
   var _path = new this.$.oFile(this.path);
@@ -563,7 +564,7 @@ $.oDrawing.prototype.refreshPreview = function () {
 * @param {oDrawing.ART_LAYER}   [artLayer]      activate the given art layer
 * @return {bool}   success of setting the drawing as current
 */
-$.oDrawing.prototype.setAsActiveDrawing = function (artLayer) {
+exports.oDrawing.prototype.setAsActiveDrawing = function (artLayer) {
   if (this.$.batchMode) {
     this.$.debug("Setting as active drawing not available in batch mode", this.$.DEBUG_LEVEL.ERROR);
     return false;
@@ -595,7 +596,8 @@ $.oDrawing.prototype.setAsActiveDrawing = function (artLayer) {
  * @param {string}   [newName]   A new name for the drawing. By default, the name will be the number of the frame.
  * @returns {$.oDrawing}   the newly created drawing
  */
-$.oDrawing.prototype.duplicate = function(frame, newName, duplicateSynchedDrawings){
+
+exports.oDrawing.prototype.duplicate = function(frame, newName, duplicateSynchedDrawings) {
   var _element = this.element
   if (typeof duplicateSynchedDrawings === 'undefined') duplicateSynchedDrawings = true; // hidden parameter used to avoid recursion bomb
   if (typeof frame ==='undefined') var frame = this.$.scn.currentFrame;
@@ -621,7 +623,7 @@ $.oDrawing.prototype.duplicate = function(frame, newName, duplicateSynchedDrawin
  * @param {string} currentId
  * @param {string} newId
  */
-$.oDrawing.prototype.replaceColorId = function (currentId, newId){
+exports.oDrawing.prototype.replaceColorId = function (currentId, newId){
   DrawingTools.recolorDrawing( this._key, [{from:currentId, to:newId}]);
 }
 
@@ -630,7 +632,7 @@ $.oDrawing.prototype.replaceColorId = function (currentId, newId){
  * Copies the contents of the Drawing into the clipboard
  * @param {oDrawing.ART_LAYER} [artLayer]    Specify to only copy the contents of the specified artLayer
  */
-$.oDrawing.prototype.copyContents = function (artLayer) {
+exports.oDrawing.prototype.copyContents = function (artLayer) {
 
   var _current = this.setAsActiveDrawing(artLayer);
   if (!_current) {
@@ -650,7 +652,7 @@ $.oDrawing.prototype.copyContents = function (artLayer) {
  * Pastes the contents of the clipboard into the Drawing
  * @param {oDrawing.ART_LAYER} [artLayer]    Specify to only paste the contents onto the specified artLayer
  */
-$.oDrawing.prototype.pasteContents = function (artLayer) {
+exports.oDrawing.prototype.pasteContents = function (artLayer) {
 
   var _current = this.setAsActiveDrawing(artLayer);
   if (!_current) {
@@ -671,7 +673,7 @@ $.oDrawing.prototype.pasteContents = function (artLayer) {
 * @param {oDrawing.LINE_END_TYPE}     endType        the type of line ends to set.
 * @param {oDrawing.ART_LAYER}        [artLayer]      only apply to provided art Layer.
 */
-$.oDrawing.prototype.setLineEnds = function (endType, artLayer) {
+exports.oDrawing.prototype.setLineEnds = function (endType, artLayer) {
   if (this.$.batchMode) {
     this.$.debug("setting line ends not available in batch mode", this.$.DEBUG_LEVEL.ERROR);
     return;
@@ -703,7 +705,7 @@ $.oDrawing.prototype.setLineEnds = function (endType, artLayer) {
 * Converts the Drawing object to a string of the drawing name.
 * @return: { string }                 The name of the drawing.
 */
-$.oDrawing.prototype.toString = function () {
+exports.oDrawing.prototype.toString = function () {
   return this.name;
 }
 
@@ -727,7 +729,7 @@ $.oDrawing.prototype.toString = function () {
  * @param   {int}                    index                      The artLayerIndex (0: underlay, 1: line art, 2: color art, 3:overlay).
  * @param   {$.oDrawing}             oDrawingObject             The oDrawing this layer belongs to.
  */
-$.oArtLayer = function (index, oDrawingObject) {
+exports.oArtLayer = function (index, oDrawingObject) {
   this._layerIndex = index;
   this._drawing = oDrawingObject;
   //log(this._drawing._key)
@@ -740,7 +742,7 @@ $.oArtLayer = function (index, oDrawingObject) {
  * @name $.oArtLayer#name
  * @type {string}
  */
-Object.defineProperty($.oArtLayer.prototype, 'name', {
+Object.defineProperty(exports.oArtLayer.prototype, 'name', {
   get: function(){
     var names = ["underlay", "colorArt", "lineArt", "overlay"];
     return names[this._layerIndex];
@@ -753,7 +755,7 @@ Object.defineProperty($.oArtLayer.prototype, 'name', {
  * @name $.oArtLayer#shapes
  * @type {$.oShape[]}
  */
-Object.defineProperty($.oArtLayer.prototype, 'shapes', {
+Object.defineProperty(exports.oArtLayer.prototype, 'shapes', {
   get: function () {
     if (!this.hasOwnProperty("_shapes")){
       var _shapesNum = Drawing.query.getNumberOfLayers(this._key);
@@ -773,7 +775,7 @@ Object.defineProperty($.oArtLayer.prototype, 'shapes', {
  * @name $.oArtLayer#strokes
  * @type {$.oStroke[]}
  */
-Object.defineProperty($.oArtLayer.prototype, 'strokes', {
+Object.defineProperty(exports.oArtLayer.prototype, 'strokes', {
   get: function () {
     var _strokes = [];
 
@@ -792,7 +794,7 @@ Object.defineProperty($.oArtLayer.prototype, 'strokes', {
  * @name $.oArtLayer#contours
  * @type {$.oContour[]}
  */
-Object.defineProperty($.oArtLayer.prototype, 'contours', {
+Object.defineProperty(exports.oArtLayer.prototype, 'contours', {
   get: function () {
     var _contours = [];
 
@@ -811,7 +813,7 @@ Object.defineProperty($.oArtLayer.prototype, 'contours', {
  * @name $.oArtLayer#boundingBox
  * @type {$.oBox}
  */
-Object.defineProperty($.oArtLayer.prototype, 'boundingBox', {
+Object.defineProperty(exports.oArtLayer.prototype, 'boundingBox', {
   get: function () {
     var _box = Drawing.query.getBox(this._key);
     if (_box.empty) return null;
@@ -827,7 +829,7 @@ Object.defineProperty($.oArtLayer.prototype, 'boundingBox', {
  * @name $.oArtLayer#selectedShapes
  * @type {$.oShape[]}
  */
-Object.defineProperty($.oArtLayer.prototype, 'selectedShapes', {
+Object.defineProperty(exports.oArtLayer.prototype, 'selectedShapes', {
   get: function () {
     var _shapes = Drawing.selection.get(this._key).selectedLayers;
     var _artLayer = this;
@@ -842,7 +844,7 @@ Object.defineProperty($.oArtLayer.prototype, 'selectedShapes', {
  * @name $.oArtLayer#selectedStrokes
  * @type {$.oStroke[]}
  */
-Object.defineProperty($.oArtLayer.prototype, 'selectedStrokes', {
+Object.defineProperty(exports.oArtLayer.prototype, 'selectedStrokes', {
   get: function () {
     var _shapes = this.selectedShapes;
     var _strokes = [];
@@ -861,7 +863,7 @@ Object.defineProperty($.oArtLayer.prototype, 'selectedStrokes', {
  * @name $.oArtLayer#selectedContours
  * @type {$.oContour[]}
  */
-Object.defineProperty($.oArtLayer.prototype, 'selectedContours', {
+Object.defineProperty(exports.oArtLayer.prototype, 'selectedContours', {
   get: function () {
     var _shapes = this.selectedShapes;
     var _contours = [];
@@ -883,7 +885,7 @@ Object.defineProperty($.oArtLayer.prototype, 'selectedContours', {
  * @readonly
  * @private
  */
-Object.defineProperty($.oArtLayer.prototype, 'drawingData', {
+Object.defineProperty(exports.oArtLayer.prototype, 'drawingData', {
   get: function () {
     var _data = this._drawing.drawingData
     for (var i in _data.arts){
@@ -906,7 +908,7 @@ Object.defineProperty($.oArtLayer.prototype, 'drawingData', {
  * @param {object}         [fillStyle=null]    The fill information to fill the circle with.
  * @returns {$.oShape}  the created shape containing the circle.
 */
-$.oArtLayer.prototype.drawCircle = function(center, radius, lineStyle, fillStyle){
+exports.oArtLayer.prototype.drawCircle = function(center, radius, lineStyle, fillStyle){
   if (typeof fillStyle === 'undefined') var fillStyle = null;
 
   var arg = {
@@ -927,7 +929,7 @@ $.oArtLayer.prototype.drawCircle = function(center, radius, lineStyle, fillStyle
  * @param {bool}   [polygon]            Wether bezier handles should be created for the points in the path (ignores "onCurve" properties of oVertex from path)
  * @param {bool}   [createUnderneath]   Wether the new shape will appear on top or underneath the contents of the layer. (not working yet)
  */
-$.oArtLayer.prototype.drawShape = function(path, lineStyle, fillStyle, polygon, createUnderneath){
+exports.oArtLayer.prototype.drawShape = function(path, lineStyle, fillStyle, polygon, createUnderneath){
   if (typeof fillStyle === 'undefined') var fillStyle = new this.$.oFillStyle();
   if (typeof lineStyle === 'undefined') var lineStyle = new this.$.oLineStyle();
   if (typeof polygon === 'undefined') var polygon = false;
@@ -982,7 +984,7 @@ $.oArtLayer.prototype.drawShape = function(path, lineStyle, fillStyle, polygon, 
  * @param {$.oLineStyle}   lineStyle     the line style to draw with.
  * @returns {$.oShape} the shape containing the added stroke.
  */
-$.oArtLayer.prototype.drawStroke = function(path, lineStyle){
+exports.oArtLayer.prototype.drawStroke = function(path, lineStyle){
   return this.drawShape(path, lineStyle, null);
 };
 
@@ -993,7 +995,7 @@ $.oArtLayer.prototype.drawStroke = function(path, lineStyle){
  * @param {$.oFillStyle}   fillStyle     the fill style to draw with.
  * @returns {$.oShape} the shape newly created from the path.
  */
-$.oArtLayer.prototype.drawContour = function(path, fillStyle){
+exports.oArtLayer.prototype.drawContour = function(path, fillStyle){
   return this.drawShape(path, null, fillStyle);
 };
 
@@ -1008,7 +1010,7 @@ $.oArtLayer.prototype.drawContour = function(path, fillStyle){
  * @param {$.oFillStyle} fillStyle  a fill style to use for the rectange fill.
  * @returns {$.oShape} the shape containing the added stroke.
  */
-$.oArtLayer.prototype.drawRectangle = function(x, y, width, height, lineStyle, fillStyle){
+exports.oArtLayer.prototype.drawRectangle = function(x, y, width, height, lineStyle, fillStyle){
   if (typeof fillStyle === 'undefined') var fillStyle = null;
 
   var path = [
@@ -1031,7 +1033,7 @@ $.oArtLayer.prototype.drawRectangle = function(x, y, width, height, lineStyle, f
  * @param {$.oLineStyle} lineStyle
  * @returns {$.oShape} the shape containing the added line.
  */
-$.oArtLayer.prototype.drawLine = function(startPoint, endPoint, lineStyle){
+exports.oArtLayer.prototype.drawLine = function(startPoint, endPoint, lineStyle){
   var path = [{x:startPoint.x,y:startPoint.y,onCurve:true},{x:endPoint.x,y:endPoint.y,onCurve:true}];
 
   return this.drawShape(path, lineStyle, null);
@@ -1041,7 +1043,7 @@ $.oArtLayer.prototype.drawLine = function(startPoint, endPoint, lineStyle){
 /**
  * Removes the contents of the art layer.
  */
-$.oArtLayer.prototype.clear = function(){
+exports.oArtLayer.prototype.clear = function(){
   var _shapes = this.shapes;
   this.$.debug(_shapes, this.$.DEBUG_LEVEL.DEBUG);
   for (var i=_shapes.length - 1; i>=0; i--){
@@ -1056,7 +1058,7 @@ $.oArtLayer.prototype.clear = function(){
  *
  * @return {$.oShape}
  */
-$.oArtLayer.prototype.getShapeByIndex = function (index) {
+exports.oArtLayer.prototype.getShapeByIndex = function (index) {
   return new this.$.oShape(index, this);
 }
 
@@ -1064,7 +1066,7 @@ $.oArtLayer.prototype.getShapeByIndex = function (index) {
 /**
  * @private
  */
-$.oArtLayer.prototype.toString = function(){
+exports.oArtLayer.prototype.toString = function(){
   return "Object $.oArtLayer ["+this.name+"]";
 }
 
@@ -1090,7 +1092,7 @@ $.oArtLayer.prototype.toString = function(){
  * @param {string}     colorId             the color Id to paint the line with.
  * @param {$.oStencil} stencil             the stencil object representing the thickness keys
  */
-$.oLineStyle = function (colorId, stencil) {
+exports.oLineStyle = function (colorId, stencil) {
   if (typeof minThickness === 'undefined') var minThickness = PenstyleManager.getCurrentPenstyleMinimumSize();
   if (typeof maxThickness === 'undefined') {
     var maxThickness = PenstyleManager.getCurrentPenstyleMaximumSize();
@@ -1124,7 +1126,7 @@ $.oLineStyle = function (colorId, stencil) {
  * @name $.oLineStyle#minThickness
  * @type {float}
  */
-Object.defineProperty($.oLineStyle.prototype, "minThickness", {
+Object.defineProperty(exports.oLineStyle.prototype, "minThickness", {
   get: function(){
     return this.stencil.minThickness;
   },
@@ -1140,7 +1142,7 @@ Object.defineProperty($.oLineStyle.prototype, "minThickness", {
  * @name $.oLineStyle#maxThickness
  * @type {float}
  */
-Object.defineProperty($.oLineStyle.prototype, "maxThickness", {
+Object.defineProperty(exports.oLineStyle.prototype, "maxThickness", {
   get: function(){
     return this.stencil.maxThickness;
   },
@@ -1172,7 +1174,7 @@ Object.defineProperty($.oLineStyle.prototype, "maxThickness", {
  * @property {int}          index       the index of the shape in the parent artLayer
  * @property {$.oArtLayer}  artLayer    the art layer that contains this shape
  */
-$.oShape = function (index, oArtLayerObject) {
+exports.oShape = function (index, oArtLayerObject) {
   this.index = index;
   this.artLayer = oArtLayerObject;
 }
@@ -1185,7 +1187,7 @@ $.oShape = function (index, oArtLayerObject) {
  * @private
  * @readonly
  */
-Object.defineProperty($.oShape.prototype, '_key', {
+Object.defineProperty(exports.oShape.prototype, '_key', {
   get: function () {
     var _key = this.artLayer._key;
     return { drawing: _key.drawing, art: _key.art, layers: [this.index] };
@@ -1200,7 +1202,7 @@ Object.defineProperty($.oShape.prototype, '_key', {
  * @readonly
  * @private
  */
-Object.defineProperty($.oShape.prototype, '_data', {
+Object.defineProperty(exports.oShape.prototype, '_data', {
   get: function () {
     return this.artLayer.drawingData.layers[this.index];
   }
@@ -1213,7 +1215,7 @@ Object.defineProperty($.oShape.prototype, '_data', {
  * @type {$.oShape[]}
  * @readonly
  */
-Object.defineProperty($.oShape.prototype, 'strokes', {
+Object.defineProperty(exports.oShape.prototype, 'strokes', {
   get: function () {
     if (!this.hasOwnProperty("_strokes")) {
       var _data = this._data;
@@ -1235,7 +1237,7 @@ Object.defineProperty($.oShape.prototype, 'strokes', {
  * @type {$.oContour[]}
  * @readonly
  */
- Object.defineProperty($.oShape.prototype, 'contours', {
+ Object.defineProperty(exports.oShape.prototype, 'contours', {
   get: function () {
     if (!this.hasOwnProperty("_contours")) {
       var _data = this._data
@@ -1257,7 +1259,7 @@ Object.defineProperty($.oShape.prototype, 'strokes', {
  * @type {$.oFillStyle[]}
  * @readonly
  */
-Object.defineProperty($.oShape.prototype, 'fills', {
+Object.defineProperty(exports.oShape.prototype, 'fills', {
   get: function () {
     if (!this.hasOwnProperty("_fills")) {
       var _data = this._data
@@ -1277,7 +1279,7 @@ Object.defineProperty($.oShape.prototype, 'fills', {
  * @type {$.oStencil[]}
  * @readonly
  */
-Object.defineProperty($.oShape.prototype, 'stencils', {
+Object.defineProperty(exports.oShape.prototype, 'stencils', {
   get: function () {
     if (!this.hasOwnProperty("_stencils")) {
       var _data = this._data;
@@ -1296,7 +1298,7 @@ Object.defineProperty($.oShape.prototype, 'stencils', {
  * @type {$.oBox}
  * @readonly
  */
-Object.defineProperty($.oShape.prototype, 'bounds', {
+Object.defineProperty(exports.oShape.prototype, 'bounds', {
   get: function () {
     var _bounds = new this.$.oBox();
     var _contours = this.contours;
@@ -1320,7 +1322,7 @@ Object.defineProperty($.oShape.prototype, 'bounds', {
  * @type {float}
  * @readonly
  */
-Object.defineProperty($.oShape.prototype, 'x', {
+Object.defineProperty(exports.oShape.prototype, 'x', {
   get: function () {
     return this.bounds.left;
   }
@@ -1333,7 +1335,7 @@ Object.defineProperty($.oShape.prototype, 'x', {
  * @type {float}
  * @readonly
  */
-Object.defineProperty($.oShape.prototype, 'y', {
+Object.defineProperty(exports.oShape.prototype, 'y', {
   get: function () {
     return this.bounds.top;
   }
@@ -1346,7 +1348,7 @@ Object.defineProperty($.oShape.prototype, 'y', {
  * @type {float}
  * @readonly
  */
-Object.defineProperty($.oShape.prototype, 'width', {
+Object.defineProperty(exports.oShape.prototype, 'width', {
   get: function () {
     return this.bounds.width;
   }
@@ -1359,7 +1361,7 @@ Object.defineProperty($.oShape.prototype, 'width', {
  * @type {float}
  * @readonly
  */
-Object.defineProperty($.oShape.prototype, 'height', {
+Object.defineProperty(exports.oShape.prototype, 'height', {
   get: function () {
     return this.bounds.height;
   }
@@ -1371,7 +1373,7 @@ Object.defineProperty($.oShape.prototype, 'height', {
  * @name $.oShape#selected
  * @type {bool}
  */
-Object.defineProperty($.oShape.prototype, 'selected', {
+Object.defineProperty(exports.oShape.prototype, 'selected', {
   get: function () {
     var _selection = this.artLayer._selectedShapes;
     var _indices = _selection.map(function (x) { return x.index });
@@ -1410,7 +1412,7 @@ Object.defineProperty($.oShape.prototype, 'selected', {
  * Updates the index of all other oShapes on the artLayer in order to
  * keep tracking all of them without having to query the drawing again.
  */
-$.oShape.prototype.remove = function(){
+exports.oShape.prototype.remove = function(){
   DrawingTools.deleteLayers(this._key);
 
   // update shapes list for this artLayer
@@ -1432,7 +1434,7 @@ $.oShape.prototype.remove = function(){
  * Get them again with artlayer.shapes.
  * @deprecated use oShape.remove instead
  */
-$.oShape.prototype.deleteShape = function(){
+exports.oShape.prototype.deleteShape = function(){
   this.remove();
 }
 
@@ -1443,12 +1445,12 @@ $.oShape.prototype.deleteShape = function(){
  *
  * @returns {$.oStroke}
  */
-$.oShape.prototype.getStrokeByIndex = function (index) {
+exports.oShape.prototype.getStrokeByIndex = function (index) {
   return this.strokes[index];
 }
 
 
-$.oShape.prototype.toString = function (){
+exports.oShape.prototype.toString = function (){
   return "<oShape index:"+this.index+", layer:"+this.artLayer.name+", drawing:'"+this.artLayer._drawing.name+"'>"
 }
 
@@ -1473,7 +1475,7 @@ $.oShape.prototype.toString = function (){
  * @param {string}     colorId             the color Id to paint the line with.
  * @param {object}     fillMatrix
  */
-$.oFillStyle = function (colorId, fillMatrix) {
+exports.oFillStyle = function (colorId, fillMatrix) {
   if (typeof fillMatrix === 'undefined') var fillMatrix = {
     "ox": 1,
     "oy": 1,
@@ -1502,7 +1504,7 @@ $.oFillStyle = function (colorId, fillMatrix) {
 }
 
 
-$.oFillStyle.prototype.toString = function(){
+exports.oFillStyle.prototype.toString = function(){
   return "<oFillStyle colorId:"+this.colorId+", matrix:"+JSON.stringify(this.fillMatrix)+">";
 }
 
@@ -1529,7 +1531,7 @@ $.oFillStyle.prototype.toString = function(){
  * @property {$.oShape}     shape       the shape that contains this stroke
  * @property {$.oArtLayer}  artLayer    the art layer that contains this stroke
  */
-$.oStroke = function (index, strokeObject, oShapeObject) {
+exports.oStroke = function (index, strokeObject, oShapeObject) {
   this.index = index;
   this.shape = oShapeObject;
   this.artLayer = oShapeObject.artLayer;
@@ -1543,7 +1545,7 @@ $.oStroke = function (index, strokeObject, oShapeObject) {
  * @type {$.oVertex[]}
  * @readonly
  */
-Object.defineProperty($.oStroke.prototype, "path", {
+Object.defineProperty(exports.oStroke.prototype, "path", {
   get: function () {
     // path vertices get cached
     if (!this.hasOwnProperty("_path")){
@@ -1566,7 +1568,7 @@ Object.defineProperty($.oStroke.prototype, "path", {
  * @type {$.oVertex[]}
  * @readonly
  */
-Object.defineProperty($.oStroke.prototype, "points", {
+Object.defineProperty(exports.oStroke.prototype, "points", {
   get: function () {
     return this.path.filter(function(x){return x.onCurve});
   }
@@ -1579,7 +1581,7 @@ Object.defineProperty($.oStroke.prototype, "points", {
  * @type {$.oVertex[][]}
  * @readonly
  */
-Object.defineProperty($.oStroke.prototype, "segments", {
+Object.defineProperty(exports.oStroke.prototype, "segments", {
   get: function () {
     var _points = this.points;
     var _path = this.path;
@@ -1602,7 +1604,7 @@ Object.defineProperty($.oStroke.prototype, "segments", {
  * @name $.oStroke#index
  * @type {int}
  */
-Object.defineProperty($.oStroke.prototype, "index", {
+Object.defineProperty(exports.oStroke.prototype, "index", {
   get: function () {
     this.$.debug("stroke object : "+JSON.stringify(this._stroke, null, "  "), this.$.DEBUG_LEVEL.DEBUG);
     return this._data.strokeIndex;
@@ -1615,7 +1617,7 @@ Object.defineProperty($.oStroke.prototype, "index", {
  * @name $.oStroke#style
  * @type {$.oLineStyle}
  */
-Object.defineProperty($.oStroke.prototype, "style", {
+Object.defineProperty(exports.oStroke.prototype, "style", {
   get: function () {
     if (this._data.invisible){
       return null;
@@ -1633,7 +1635,7 @@ Object.defineProperty($.oStroke.prototype, "style", {
  * @name $.oStroke#closed
  * @type {bool}
  */
-Object.defineProperty($.oStroke.prototype, "closed", {
+Object.defineProperty(exports.oStroke.prototype, "closed", {
   get: function () {
     var _path = this.path;
     $.log(_path)
@@ -1649,7 +1651,7 @@ Object.defineProperty($.oStroke.prototype, "closed", {
  * @type {$.oBox}
  * @readonly
  */
- Object.defineProperty($.oStroke.prototype, 'bounds', {
+ Object.defineProperty(exports.oStroke.prototype, 'bounds', {
   get: function () {
     var _bounds = new this.$.oBox();
     // since Harmony doesn't allow natively to calculate the bounding box of a string,
@@ -1687,7 +1689,7 @@ for (var i in sel){
   }
 }
  */
-$.oStroke.prototype.getIntersections = function (stroke){
+exports.oStroke.prototype.getIntersections = function (stroke){
   if (typeof stroke !== 'undefined'){
     // get intersection with provided stroke only
     var _key = { "path0": [{ path: this.path }], "path0": [{ path: stroke.path }] };
@@ -1740,7 +1742,7 @@ intersection2.stroke.addPoints([intersection2.strokePoint]);
 // add the points on the stroke
 sel.addPoints([intersection1.ownPoint, intersection2.ownPoint]);
 */
-$.oStroke.prototype.addPoints = function (pointsToAdd) {
+exports.oStroke.prototype.addPoints = function (pointsToAdd) {
   // calculate the points that will be created
   var points = Drawing.geometry.insertPoints({path:this._data.path, params : pointsToAdd});
 
@@ -1786,7 +1788,7 @@ $.oStroke.prototype.addPoints = function (pointsToAdd) {
  * fetch the stroke information again to update it after modifications.
  * @returns {object} the data definition of the stroke, for internal use.
  */
-$.oStroke.prototype.updateDefinition = function(){
+exports.oStroke.prototype.updateDefinition = function(){
   var _key = this.artLayer._key;
   var strokes = Drawing.query.getStrokes(_key);
   this._data = strokes.layers[this.shape.index].strokes[this.index];
@@ -1803,7 +1805,7 @@ $.oStroke.prototype.updateDefinition = function(){
  * @param {oPoint}  point
  * @return {float}  the strokePosition of the point on the stroke (@see $.oVertex#strokePosition)
  */
-$.oStroke.prototype.getPointPosition = function(point){
+exports.oStroke.prototype.getPointPosition = function(point){
   var arg = {
     path : this.path,
     points: [{x:point.x, y:point.y}]
@@ -1821,14 +1823,14 @@ $.oStroke.prototype.getPointPosition = function(point){
  * @param {float}  position
  * @return {$.oPoint} an oPoint object containing the coordinates.
  */
-$.oStroke.prototype.getPointCoordinates = function(position){
+exports.oStroke.prototype.getPointCoordinates = function(position){
   var arg = {
     path : this.path,
     params : [ position ]
   };
   var point = Drawing.geometry.evaluate(arg)[0];
 
-  return new $.oPoint(point.x, point.y);
+  return new $.oPoint(point.x, point.y); // should this be this.$.oPoint?
 }
 
 
@@ -1838,7 +1840,7 @@ $.oStroke.prototype.getPointCoordinates = function(position){
  * @param {$.oPoint} point
  * @returns {$.oPoint}
  */
-$.oStroke.prototype.getClosestPoint = function (point){
+exports.oStroke.prototype.getClosestPoint = function (point){
   var arg = {
     path : this.path,
     points: [{x:point.x, y:point.y}]
@@ -1848,7 +1850,7 @@ $.oStroke.prototype.getClosestPoint = function (point){
   // the original query and a "closestPoint" key that contains the information.
   var _result = Drawing.geometry.getClosestPoint(arg)[0];
 
-  return new $.oPoint(_result.closestPoint.x, _result.closestPoint.y);
+  return new $.oPoint(_result.closestPoint.x, _result.closestPoint.y); // should this be this.$.oPoint?
 }
 
 
@@ -1858,7 +1860,7 @@ $.oStroke.prototype.getClosestPoint = function (point){
  * @param {$.oPoint} point
  * @returns {float}
  */
-$.oStroke.prototype.getPointDistance = function (point){
+exports.oStroke.prototype.getPointDistance = function (point){
   var arg = {
     path : this.path,
     points: [{x:point.x, y:point.y}]
@@ -1875,7 +1877,7 @@ $.oStroke.prototype.getPointDistance = function (point){
 /**
  * @private
  */
-$.oStroke.prototype.toString = function(){
+exports.oStroke.prototype.toString = function(){
   return "<oStroke: path:"+this.path+">"
 }
 
@@ -1905,10 +1907,10 @@ $.oStroke.prototype.toString = function(){
  * @property {$.oShape}     shape       the shape that contains this stroke
  * @property {$.oArtLayer}  artLayer    the art layer that contains this stroke
  */
-$.oContour = function (index, contourObject, oShapeObject) {
+exports.oContour = function (index, contourObject, oShapeObject) {
   this.$.oStroke.call(this, index, contourObject, oShapeObject)
 }
-$.oContour.prototype = Object.create($.oStroke.prototype)
+exports.oContour.prototype = Object.create(exports.oStroke.prototype)
 
 
 /**
@@ -1916,7 +1918,7 @@ $.oContour.prototype = Object.create($.oStroke.prototype)
  * @name $.oContour#fill
  * @type {$.oFillStyle}
  */
-Object.defineProperty($.oContour.prototype, "fill", {
+Object.defineProperty(exports.oContour.prototype, "fill", {
   get: function () {
     var _data = this._data;
     return new this.$.oFillStyle(_data.colorId, _data.matrix);
@@ -1930,7 +1932,7 @@ Object.defineProperty($.oContour.prototype, "fill", {
  * @type {$.oBox}
  * @readonly
  */
- Object.defineProperty($.oContour.prototype, 'bounds', {
+ Object.defineProperty(exports.oContour.prototype, 'bounds', {
   get: function () {
     var _data = this._data;
     var _box = _data.box;
@@ -1942,7 +1944,7 @@ Object.defineProperty($.oContour.prototype, "fill", {
 /**
  * @private
  */
-$.oContour.prototype.toString = function(){
+exports.oContour.prototype.toString = function(){
   return "<oContour path:"+this.path+", fill:"+fill+">"
 }
 
@@ -1979,7 +1981,7 @@ $.oContour.prototype.toString = function(){
  * @property {bool}      onCurve   whether the point is a bezier handle or situated on the curve
  * @property {int}       index     the index of the point on the stroke
  */
-$.oVertex = function(stroke, x, y, onCurve, index){
+exports.oVertex = function(stroke, x, y, onCurve, index){
   if (typeof onCurve === 'undefined') var onCurve = false;
   if (typeof index === 'undefined') var index = stroke.getPointPosition({x:x, y:y});
 
@@ -1997,7 +1999,7 @@ $.oVertex = function(stroke, x, y, onCurve, index){
  * @type {float}
  * @readonly
  */
-Object.defineProperty($.oVertex.prototype, 'strokePosition', {
+Object.defineProperty(exports.oVertex.prototype, 'strokePosition', {
   get: function(){
     var _position = this.stroke.getPointPosition(this);
     return _position;
@@ -2011,7 +2013,7 @@ Object.defineProperty($.oVertex.prototype, 'strokePosition', {
  * @type {oPoint}
  * @readonly
  */
-Object.defineProperty($.oVertex.prototype, 'position', {
+Object.defineProperty(exports.oVertex.prototype, 'position', {
   get: function(){
     var _position = new this.$.oPoint(this.x, this.y, 0);
     return _position;
@@ -2026,7 +2028,7 @@ Object.defineProperty($.oVertex.prototype, 'position', {
  * @type {float}
  * @readonly
  */
-Object.defineProperty($.oVertex.prototype, 'angleRight', {
+Object.defineProperty(exports.oVertex.prototype, 'angleRight', {
   get: function(){
     var _index = this.index+1;
     var _path = this.stroke.path;
@@ -2057,7 +2059,7 @@ Object.defineProperty($.oVertex.prototype, 'angleRight', {
  * @type {float}
  * @readonly
  */
-Object.defineProperty($.oVertex.prototype, 'angleLeft', {
+Object.defineProperty(exports.oVertex.prototype, 'angleLeft', {
   get: function(){
     var _index = this.index-1;
     var _path = this.stroke.path;
@@ -2084,7 +2086,7 @@ Object.defineProperty($.oVertex.prototype, 'angleLeft', {
 /**
  * @private
  */
-$.oVertex.prototype.toString = function(){
+exports.oVertex.prototype.toString = function(){
  return "oVertex : { index:"+this.index+", x: "+this.x+", y: "+this.y+", onCurve: "+this.onCurve+", strokePosition: "+this.strokePosition+" }"
 }
 
@@ -2112,7 +2114,7 @@ $.oVertex.prototype.toString = function(){
  * @property {string}  type                  the type of stencil
  * @property {Object}  thicknessPathObject   the description of the shape of the stencil
  */
-$.oStencil = function (name, type, thicknessPathObject) {
+exports.oStencil = function (name, type, thicknessPathObject) {
   this.name = name;
   this.type = type;
   this.thicknessPathObject = thicknessPathObject;
@@ -2125,7 +2127,7 @@ $.oStencil = function (name, type, thicknessPathObject) {
  * @name $.oStencil#minThickness
  * @type {float}
  */
-Object.defineProperty($.oStencil.prototype, "minThickness", {
+Object.defineProperty(exports.oStencil.prototype, "minThickness", {
   get: function(){
     return this.thicknessPathObject.minThickness;
   },
@@ -2141,7 +2143,7 @@ Object.defineProperty($.oStencil.prototype, "minThickness", {
  * @name $.oStencil#maxThickness
  * @type {float}
  */
-Object.defineProperty($.oStencil.prototype, "maxThickness", {
+Object.defineProperty(exports.oStencil.prototype, "maxThickness", {
   get: function(){
     return this.thicknessPathObject.maxThickness;
   },
@@ -2156,7 +2158,7 @@ Object.defineProperty($.oStencil.prototype, "maxThickness", {
  * Parses the xml string of the stencil xml description to create an object with all the information from it.
  * @private
  */
-$.oStencil.getFromXml = function (xmlString) {
+exports.oStencil.getFromXml = function (xmlString) {
   var object = this.prototype.$.oStencil.getSettingsFromXml(xmlString)
 
   var maxThickness = object.mainBrushShape.sizeRange.maxValue
@@ -2188,7 +2190,7 @@ $.oStencil.getFromXml = function (xmlString) {
  * Parses the xml string of the stencil xml description to create an object with all the information from it.
  * @private
  */
-$.oStencil.getSettingsFromXml = function (xmlString) {
+exports.oStencil.getSettingsFromXml = function (xmlString) {
   var object = {};
   var objectRE = /<(\w+)>([\S\s]*?)<\/\1>/igm
   var match;
@@ -2222,6 +2224,6 @@ $.oStencil.getSettingsFromXml = function (xmlString) {
   return object;
 }
 
-$.oStencil.prototype.toString = function (){
+exports.oStencil.prototype.toString = function (){
   return "$.oStencil: '" + this.name + "'"
 }

--- a/openHarmony/openHarmony_drawing.js
+++ b/openHarmony/openHarmony_drawing.js
@@ -477,7 +477,7 @@ exports.oDrawing.prototype.importBitmap = function (file, convertToTvg) {
 
     var _convertedFilePath = tempFolder.path + "/" + file.name + ".tvg";
     var _convertProcess = new this.$.oProcess(_bin, ["-outformat", "TVG", "-debug", "-resolution", res_x, res_y, "-outfile", _convertedFilePath, file.path]);
-    log(_convertProcess.execute())
+    this.$.log(_convertProcess.execute())
 
     var convertedFile = new this.$.oFile(_convertedFilePath);
     if (!convertedFile.exists) throw new Error ("Converting " + file.path + " to TVG has failed.");
@@ -732,7 +732,7 @@ exports.oDrawing.prototype.toString = function () {
 exports.oArtLayer = function (index, oDrawingObject) {
   this._layerIndex = index;
   this._drawing = oDrawingObject;
-  //log(this._drawing._key)
+  //this.$.log(this._drawing._key)
   this._key = { "drawing": this._drawing._key, "art": index }
 }
 
@@ -818,7 +818,7 @@ Object.defineProperty(exports.oArtLayer.prototype, 'boundingBox', {
     var _box = Drawing.query.getBox(this._key);
     if (_box.empty) return null;
 
-    var _boundingBox = new $.oBox(_box.x0, _box.y0, _box.x1, _box.y1);
+    var _boundingBox = new this.$.oBox(_box.x0, _box.y0, _box.x1, _box.y1);
     return _boundingBox;
   }
 })
@@ -1099,7 +1099,7 @@ exports.oLineStyle = function (colorId, stencil) {
     if (!maxThickness && !minThickness) maxThickness = 1;
   }
   if (typeof stencil === 'undefined') {
-    var stencil = new $.oStencil("", "pencil", {maxThickness:maxThickness, minThickness:minThickness, keys:[]});
+    var stencil = new this.$.oStencil("", "pencil", {maxThickness:maxThickness, minThickness:minThickness, keys:[]});
   }
 
   if (typeof colorId === 'undefined'){
@@ -1638,8 +1638,8 @@ Object.defineProperty(exports.oStroke.prototype, "style", {
 Object.defineProperty(exports.oStroke.prototype, "closed", {
   get: function () {
     var _path = this.path;
-    $.log(_path)
-    $.log(_path[_path.length-1].strokePosition)
+    this.$.log(_path)
+    this.$.log(_path[_path.length-1].strokePosition)
     return _path[_path.length-1].strokePosition == 0;
   }
 })
@@ -1681,11 +1681,11 @@ for (var i in sel){
 	var intersections = sel[i].getIntersections();
 
   for (var j in intersections){
-    log("intersection : " + j);
-    log("point : " + intersections[j].point);                    // the point coordinates
-    log("strokes index : " + intersections[j].stroke.index);     // the index of the intersecting strokes in their own shape
-    log("own point : " + intersections[j].ownPoint);             // how far the intersection is on the stroke itself
-    log("stroke point : " + intersections[j].strokePoint);       // how far the intersection is on the intersecting stroke
+    $.log("intersection : " + j);
+    $.log("point : " + intersections[j].point);                    // the point coordinates
+    $.log("strokes index : " + intersections[j].stroke.index);     // the index of the intersecting strokes in their own shape
+    $.log("own point : " + intersections[j].ownPoint);             // how far the intersection is on the stroke itself
+    $.log("stroke point : " + intersections[j].strokePoint);       // how far the intersection is on the intersecting stroke
   }
 }
  */
@@ -1830,7 +1830,7 @@ exports.oStroke.prototype.getPointCoordinates = function(position){
   };
   var point = Drawing.geometry.evaluate(arg)[0];
 
-  return new $.oPoint(point.x, point.y); // should this be this.$.oPoint?
+  return new this.$.oPoint(point.x, point.y);
 }
 
 
@@ -1850,7 +1850,7 @@ exports.oStroke.prototype.getClosestPoint = function (point){
   // the original query and a "closestPoint" key that contains the information.
   var _result = Drawing.geometry.getClosestPoint(arg)[0];
 
-  return new $.oPoint(_result.closestPoint.x, _result.closestPoint.y); // should this be this.$.oPoint?
+  return new this.$.oPoint(_result.closestPoint.x, _result.closestPoint.y); // should this be this.$.oPoint?
 }
 
 
@@ -2118,7 +2118,7 @@ exports.oStencil = function (name, type, thicknessPathObject) {
   this.name = name;
   this.type = type;
   this.thicknessPathObject = thicknessPathObject;
-  // log("thicknessPath: " + JSON.stringify(this.thicknessPathObject))
+  // this.$.log("thicknessPath: " + JSON.stringify(this.thicknessPathObject))
 }
 
 

--- a/openHarmony/openHarmony_element.js
+++ b/openHarmony/openHarmony_element.js
@@ -309,7 +309,7 @@ exports.oElement.prototype.duplicate = function(name){
       var duplicateDrawing = _duplicateElement.addDrawing(0, _drawings[i].name, _drawingFile);
       _drawingFile.copy(_elementFolder, duplicateDrawing.name, true);
     }catch(err){
-      this.debug("could not copy drawing file "+_drawingFile.name+" into element "+_duplicateElement.name, this.$.DEBUG_LEVEL.ERROR);
+      this.$.debug("could not copy drawing file "+_drawingFile.name+" into element "+_duplicateElement.name, this.$.DEBUG_LEVEL.ERROR);
     }
   }
   return _duplicateElement;

--- a/openHarmony/openHarmony_element.js
+++ b/openHarmony/openHarmony_element.js
@@ -60,7 +60,7 @@
  * @property {int}                  id                          The element ID.
  * @property {$.oColumn}            oColumnObject               The column object associated to the element.
  */
-$.oElement = function( id, synchedLayer, oColumnObject){
+exports.oElement = function( id, synchedLayer, oColumnObject){
   if (typeof synchedLayer === 'undefined' || !synchedLayer) synchedLayer = null;
   this._type = "element";
 
@@ -76,7 +76,7 @@ $.oElement = function( id, synchedLayer, oColumnObject){
  * @name $.oElement#name
  * @type {string}
  */
-Object.defineProperty($.oElement.prototype, 'name', {
+Object.defineProperty(exports.oElement.prototype, 'name', {
     get : function(){
          return element.getNameById(this.id)
     },
@@ -92,7 +92,7 @@ Object.defineProperty($.oElement.prototype, 'name', {
  * @name $.oElement#path
  * @type {string}
  */
-Object.defineProperty($.oElement.prototype, 'path', {
+Object.defineProperty(exports.oElement.prototype, 'path', {
     get : function(){
          return fileMapper.toNativePath(element.completeFolder(this.id))
     }
@@ -104,7 +104,7 @@ Object.defineProperty($.oElement.prototype, 'path', {
  * @name $.oElement#drawings
  * @type {$.oDrawing[]}
  */
-Object.defineProperty($.oElement.prototype, 'drawings', {
+Object.defineProperty(exports.oElement.prototype, 'drawings', {
   get : function(){
     var _drawingsNumber = Drawing.numberOf(this.id);
     var _drawings = [];
@@ -121,7 +121,7 @@ Object.defineProperty($.oElement.prototype, 'drawings', {
  * @name $.oElement#format
  * @type {string}
  */
-Object.defineProperty($.oElement.prototype, 'format', {
+Object.defineProperty(exports.oElement.prototype, 'format', {
   get : function(){
     var _type = element.pixmapFormat(this.id);
     if (element.vectorType(this.id)) _type = "TVG";
@@ -135,7 +135,7 @@ Object.defineProperty($.oElement.prototype, 'format', {
  * @name $.oElement#palettes
  * @type {$.oPalette[]}
  */
-Object.defineProperty($.oElement.prototype, 'palettes', {
+Object.defineProperty(exports.oElement.prototype, 'palettes', {
   get: function(){
     var _paletteList = PaletteObjectManager.getPaletteListByElementId(this.id);
     var _palettes = [];
@@ -154,10 +154,10 @@ Object.defineProperty($.oElement.prototype, 'palettes', {
  * @readonly
  * @type {$.oDrawing[]}
  */
-Object.defineProperty($.oElement.prototype, 'synchedElements', {
+Object.defineProperty(exports.oElement.prototype, 'synchedElements', {
   get : function(){
     var _id = this.id;
-    return $.scene.elements.filter(function(e){return e.id == _id});
+    return this.$.scene.elements.filter(function(e){return e.id == _id});
   }
 })
 
@@ -173,7 +173,7 @@ Object.defineProperty($.oElement.prototype, 'synchedElements', {
  *
  * @return {$.oDrawing}      The added drawing
  */
-$.oElement.prototype.addDrawing = function( atFrame, name, filename, convertToTvg ){
+exports.oElement.prototype.addDrawing = function( atFrame, name, filename, convertToTvg ){
   if (typeof atFrame === 'undefined') var atFrame = 1;
   if (typeof filename === 'undefined') var filename = null;
   var nameByFrame = this.$.app.preferences.XSHEET_NAME_BY_FRAME;
@@ -222,7 +222,7 @@ $.oElement.prototype.addDrawing = function( atFrame, name, filename, convertToTv
  *
  * @return  {$.oDrawing}      The drawing found by the search
  */
-$.oElement.prototype.getDrawingByName = function ( name ){
+exports.oElement.prototype.getDrawingByName = function ( name ){
   var _drawings = this.drawings;
   for (var i in _drawings){
     if (_drawings[i].name == name) return _drawings[i];
@@ -237,7 +237,7 @@ $.oElement.prototype.getDrawingByName = function ( name ){
  *
  * @return  {$.oDrawing}      The drawing found by the search
  */
- $.oElement.prototype.getDrawingById = function ( id ){
+ exports.oElement.prototype.getDrawingById = function ( id ){
   var _drawings = this.drawings;
   for (var i in _drawings){
     if (_drawings[i].id == id) return _drawings[i];
@@ -251,7 +251,7 @@ $.oElement.prototype.getDrawingByName = function ( name ){
  * @param   {int}           [listIndex]              The index in the element palette list at which to add the newly linked palette
  * @return  {$.oPalette}    The linked element palette.
  */
-$.oElement.prototype.linkPalette = function ( oPaletteObject , listIndex){
+exports.oElement.prototype.linkPalette = function ( oPaletteObject , listIndex){
   var _paletteList = PaletteObjectManager.getPaletteListByElementId(this.id);
   if (typeof listIndex === 'undefined') var listIndex = _paletteList.numPalettes;
 
@@ -267,7 +267,7 @@ $.oElement.prototype.linkPalette = function ( oPaletteObject , listIndex){
  * @param {$.oPalette} oPaletteObject
  * @return {bool} the success of the unlinking process.
  */
-$.oElement.prototype.unlinkPalette = function (oPaletteObject) {
+exports.oElement.prototype.unlinkPalette = function (oPaletteObject) {
   var _palettes = this.palettes;
   var _ids = _palettes.map(function(x){return x.id});
   var _paletteId = oPaletteObject.id;
@@ -292,7 +292,7 @@ $.oElement.prototype.unlinkPalette = function (oPaletteObject) {
  * @param   {string}     [name]              The new name for the duplicated element.
  * @return  {$.oElement}      The duplicate element
  */
-$.oElement.prototype.duplicate = function(name){
+exports.oElement.prototype.duplicate = function(name){
   if (typeof name === 'undefined') var name = this.name;
 
   var _fieldGuide = element.fieldChart(this.id);

--- a/openHarmony/openHarmony_file.js
+++ b/openHarmony/openHarmony_file.js
@@ -57,7 +57,7 @@
  *
  * @property    {string}             path                      The path to the folder.
  */
-$.oFolder = function(path){
+exports.oFolder = function(path){
     this._type = "folder";
     this._path = fileMapper.toNativePath(path).split("\\").join("/");
 
@@ -76,7 +76,7 @@ $.oFolder = function(path){
  * @name $.oFolder#path
  * @type {string}
  */
-Object.defineProperty($.oFolder.prototype, 'path', {
+Object.defineProperty(exports.oFolder.prototype, 'path', {
     get: function(){
       return this._path;
     },
@@ -92,7 +92,7 @@ Object.defineProperty($.oFolder.prototype, 'path', {
  * @readonly
  * @type {string}
  */
-Object.defineProperty( $.oFolder.prototype, 'toonboomPath', {
+Object.defineProperty( exports.oFolder.prototype, 'toonboomPath', {
   get: function(){
     var _path = this._path;
     if (!this.$.scene.online) return _path;
@@ -112,7 +112,7 @@ Object.defineProperty( $.oFolder.prototype, 'toonboomPath', {
  * @name $.oFolder#name
  * @type {string}
  */
-Object.defineProperty($.oFolder.prototype, 'name', {
+Object.defineProperty(exports.oFolder.prototype, 'name', {
     get: function(){
         var _name = this.path.split("/");
         _name = _name.pop();
@@ -129,7 +129,7 @@ Object.defineProperty($.oFolder.prototype, 'name', {
  * @name $.oFolder#folder
  * @type {$.oFolder}
  */
-Object.defineProperty($.oFolder.prototype, 'folder', {
+Object.defineProperty(exports.oFolder.prototype, 'folder', {
     get: function(){
         var _folder = this.path.slice(0,this.path.lastIndexOf("/", this.path.length-2));
         return new this.$.oFolder(_folder);
@@ -142,7 +142,7 @@ Object.defineProperty($.oFolder.prototype, 'folder', {
  * @name $.oFolder#exists
  * @type {string}
  */
-Object.defineProperty($.oFolder.prototype, 'exists', {
+Object.defineProperty(exports.oFolder.prototype, 'exists', {
     get: function(){
         var dir = new QDir;
         dir.setPath(this.path)
@@ -157,7 +157,7 @@ Object.defineProperty($.oFolder.prototype, 'exists', {
  * @type {$.oFile[]}
  * @deprecated use oFolder.getFiles() instead to specify filter
  */
-Object.defineProperty($.oFolder.prototype, 'files', {
+Object.defineProperty(exports.oFolder.prototype, 'files', {
     get: function(){
       var dir = new QDir;
       dir.setPath(this.path);
@@ -176,7 +176,7 @@ Object.defineProperty($.oFolder.prototype, 'files', {
  * @type {$.oFile[]}
  * @deprecated oFolder.folder is the containing parent folder, it can't also mean the children folders
  */
-Object.defineProperty($.oFolder.prototype, 'folders', {
+Object.defineProperty(exports.oFolder.prototype, 'folders', {
     get: function(){
       var _dir = new QDir;
       _dir.setPath(this.path);
@@ -198,7 +198,7 @@ Object.defineProperty($.oFolder.prototype, 'folders', {
  * @name $.oFolder#content
  * @type {$.oFile/$.oFolder[] }
  */
-Object.defineProperty($.oFolder.prototype, 'content', {
+Object.defineProperty(exports.oFolder.prototype, 'content', {
     get: function(){
       var content = this.files;
           content = content.concat( this.folders );
@@ -211,7 +211,7 @@ Object.defineProperty($.oFolder.prototype, 'content', {
  * Enum for the type of content to retrieve from the oFolder.
  * @enum {QFlag}
  */
-$.oFolder.prototype.ContentType = {
+exports.oFolder.prototype.ContentType = {
   FOLDER: QDir.Filters(QDir.Dirs | QDir.NoDotAndDotDot),
   FILE: QDir.Files
 }
@@ -234,7 +234,7 @@ $.oFolder.prototype.ContentType = {
  *
  * @returns {string[]}   Names of the folder contents that match the filter and type provided.
  */
-$.oFolder.prototype.listEntries = function(contentType, filter) {
+exports.oFolder.prototype.listEntries = function(contentType, filter) {
   // Undefined filters become a wildcard
   // A single string filter becomes a single-item array
   // Array of filters are unchanged.
@@ -268,7 +268,7 @@ $.oFolder.prototype.listEntries = function(contentType, filter) {
  *
  * @returns {string[]}  Names of the files contained in the folder that match the namefilter(s).
  */
-$.oFolder.prototype.listFiles = function(filter){
+exports.oFolder.prototype.listFiles = function(filter){
   return this.listEntries(this.ContentType.FILE, filter);
 }
 
@@ -279,7 +279,7 @@ $.oFolder.prototype.listFiles = function(filter){
  *
  * @returns {$.oFile[]}  A list of files contained in the folder that match the namefilter(s), as oFile objects.
  */
-$.oFolder.prototype.getFiles = function(filter){
+exports.oFolder.prototype.getFiles = function(filter){
   var _fileList = this.listFiles(filter);
   var _files = _fileList.map(function(filePath) {
     return new this.$.oFile(this.path + "/" + filePath);
@@ -295,7 +295,7 @@ $.oFolder.prototype.getFiles = function(filter){
  *
  * @returns {string[]}  Names of the files contained in the folder that match the namefilter(s).
  */
-$.oFolder.prototype.listFolders = function(filter){
+exports.oFolder.prototype.listFolders = function(filter){
   return this.listEntries(this.ContentType.FOLDER, filter);
 }
 
@@ -306,7 +306,7 @@ $.oFolder.prototype.listFolders = function(filter){
  *
  * @returns {$.oFolder[]}  A list of folders contained in the folder that match the namefilter(s), as oFolder objects.
  */
-$.oFolder.prototype.getFolders = function(filter){
+exports.oFolder.prototype.getFolders = function(filter){
 
   var _folderList = this.listFolders(filter);
   var _folders = _folderList.map(function(folderPath) {
@@ -321,7 +321,7 @@ $.oFolder.prototype.getFolders = function(filter){
  * Creates the folder, if it doesn't already exist.
  * @returns { bool }      The existence of the newly created folder.
  */
-$.oFolder.prototype.create = function(){
+exports.oFolder.prototype.create = function(){
   if( this.exists ){
     this.$.debug("folder "+this.path+" already exists and will not be created", this.$.DEBUG_LEVEL.WARNING)
     return true;
@@ -341,21 +341,21 @@ $.oFolder.prototype.create = function(){
  * @param   {bool}     [overwrite=false]   Whether to overwrite the files that are already present at the copy location.
  * @returns {$.oFolder} the oFolder describing the newly created copy.
  */
-$.oFolder.prototype.copy = function( folderPath, copyName, overwrite ){
+exports.oFolder.prototype.copy = function( folderPath, copyName, overwrite ){
   // TODO: it should propagate errors from the recursive copy and throw them before ending?
   if (typeof overwrite === 'undefined') var overwrite = false;
   if (typeof copyName === 'undefined' || !copyName) var copyName = this.name;
-  if (!(folderPath instanceof this.$.oFolder)) folderPath = new $.oFolder(folderPath);
+  if (!(folderPath instanceof exports.oFolder)) folderPath = new this.$.oFolder(folderPath);
   if (this.name == copyName && folderPath == this.folder.path) copyName += "_copy";
 
   if (!folderPath.exists) throw new Error("Target folder " + folderPath +" doesn't exist. Can't copy folder "+this.path)
 
-  var nextFolder = new $.oFolder(folderPath.path + "/" + copyName);
+  var nextFolder = new this.$.oFolder(folderPath.path + "/" + copyName);
   nextFolder.create();
   var files = this.getFiles();
   for (var i in files){
     var _file = files[i];
-    var targetFile = new $.oFile(nextFolder.path + "/" + _file.fullName);
+    var targetFile = new this.$.oFile(nextFolder.path + "/" + _file.fullName);
 
     // deal with overwriting
     if (targetFile.exists && !overwrite){
@@ -382,10 +382,10 @@ $.oFolder.prototype.copy = function( folderPath, copyName, overwrite ){
  * @return { bool }                            The result of the move.
  * @todo implement with Robocopy
  */
-$.oFolder.prototype.move = function( destFolderPath, overwrite ){
+exports.oFolder.prototype.move = function( destFolderPath, overwrite ){
     if (typeof overwrite === 'undefined') var overwrite = false;
 
-    if (destFolderPath instanceof this.$.oFolder) destFolderPath = destFolderPath.path;
+    if (destFolderPath instanceof exports.oFolder) destFolderPath = destFolderPath.path;
 
     var dir = new Dir;
     dir.path = destFolderPath;
@@ -415,8 +415,8 @@ $.oFolder.prototype.move = function( destFolderPath, overwrite ){
  *
  * @return: { bool }                            The result of the move.
  */
-$.oFolder.prototype.moveToFolder = function( destFolderPath, overwrite ){
-  destFolderPath = (destFolderPath instanceof this.$.oFolder)?destFolderPath:new this.$.oFolder(destFolderPath)
+exports.oFolder.prototype.moveToFolder = function( destFolderPath, overwrite ){
+  destFolderPath = (destFolderPath instanceof exports.oFolder)?destFolderPath:new this.$.oFolder(destFolderPath)
 
   var folder = destFolderPath.path;
   var name = this.name;
@@ -429,7 +429,7 @@ $.oFolder.prototype.moveToFolder = function( destFolderPath, overwrite ){
  * Renames the folder
  * @param {string} newName
  */
-$.oFolder.prototype.rename = function(newName){
+exports.oFolder.prototype.rename = function(newName){
   var destFolderPath = this.folder.path+"/"+newName
   if ((new this.$.oFolder(destFolderPath)).exists) throw new Error("Can't rename folder "+this.path + " to "+newName+", a folder already exists at this location")
 
@@ -441,7 +441,7 @@ $.oFolder.prototype.rename = function(newName){
  * Deletes the folder.
  * @param   {bool}    removeContents            Whether to check if the folder contains files before deleting.
  */
-$.oFolder.prototype.remove = function (removeContents){
+exports.oFolder.prototype.remove = function (removeContents){
   if (typeof removeContents === 'undefined') var removeContents = false;
 
   if (this.listFiles.length > 0 && this.listFolders.length > 0 && !removeContents) throw new Error("Can't remove folder "+this.path+", it is not empty.")
@@ -455,14 +455,14 @@ $.oFolder.prototype.remove = function (removeContents){
  * @param   {string}   name                     The sub name of a folder or file within a directory.
  * @return: {$.oFolder/$.oFile}                 The resulting oFile or oFolder.
  */
-$.oFolder.prototype.get = function( destName ){
+exports.oFolder.prototype.get = function( destName ){
   var new_path = this.path + "/" + destName;
-  var new_folder = new $.oFolder( new_path );
+  var new_folder = new this.$.oFolder( new_path );
   if( new_folder.exists ){
     return new_folder;
   }
 
-  var new_file = new $.oFile( new_path );
+  var new_file = new this.$.oFile( new_path );
   if( new_file.exists ){
     return new_file;
   }
@@ -475,7 +475,7 @@ $.oFolder.prototype.get = function( destName ){
  * Used in converting the folder to a string value, provides the string-path.
  * @return  {string}   The folder path's as a string.
  */
-$.oFolder.prototype.toString = function(){
+exports.oFolder.prototype.toString = function(){
     return this.path;
 }
 
@@ -499,7 +499,7 @@ $.oFolder.prototype.toString = function(){
  *
  * @property    {string}             path                     The path to the file.
  */
-$.oFile = function(path){
+exports.oFile = function(path){
   this._type = "file";
   this._path = fileMapper.toNativePath(path).split('\\').join('/');
 
@@ -518,7 +518,7 @@ $.oFile = function(path){
  * @name $.oFile#fullName
  * @type {string}
  */
-Object.defineProperty($.oFile.prototype, 'fullName', {
+Object.defineProperty(exports.oFile.prototype, 'fullName', {
     get: function(){
         var _name = this.path.slice( this.path.lastIndexOf("/")+1 );
         return _name;
@@ -531,7 +531,7 @@ Object.defineProperty($.oFile.prototype, 'fullName', {
  * @name $.oFile#name
  * @type {string}
  */
-Object.defineProperty($.oFile.prototype, 'name', {
+Object.defineProperty(exports.oFile.prototype, 'name', {
     get: function(){
       var _fullName = this.fullName;
       if (_fullName.indexOf(".") == -1) return _fullName;
@@ -550,7 +550,7 @@ Object.defineProperty($.oFile.prototype, 'name', {
  * @name $.oFile#extension
  * @type {string}
  */
-Object.defineProperty($.oFile.prototype, 'extension', {
+Object.defineProperty(exports.oFile.prototype, 'extension', {
     get: function(){
       var _fullName = this.fullName;
       if (_fullName.indexOf(".") == -1) return "";
@@ -566,7 +566,7 @@ Object.defineProperty($.oFile.prototype, 'extension', {
  * @name $.oFile#folder
  * @type {$.oFolder}
  */
-Object.defineProperty($.oFile.prototype, 'folder', {
+Object.defineProperty(exports.oFile.prototype, 'folder', {
     get: function(){
         var _folder = this.path.slice(0,this.path.lastIndexOf("/"));
         return new this.$.oFolder(_folder);
@@ -579,7 +579,7 @@ Object.defineProperty($.oFile.prototype, 'folder', {
  * @name $.oFile#exists
  * @type {bool}
  */
-Object.defineProperty($.oFile.prototype, 'exists', {
+Object.defineProperty(exports.oFile.prototype, 'exists', {
     get: function(){
         var _file = new File( this.path );
         return _file.exists;
@@ -592,7 +592,7 @@ Object.defineProperty($.oFile.prototype, 'exists', {
  * @name $.oFile#path
  * @type {string}
  */
-Object.defineProperty( $.oFile.prototype, 'path', {
+Object.defineProperty( exports.oFile.prototype, 'path', {
   get: function(){
     return this._path;
   },
@@ -609,7 +609,7 @@ Object.defineProperty( $.oFile.prototype, 'path', {
  * @readonly
  * @type {string}
  */
-Object.defineProperty( $.oFile.prototype, 'toonboomPath', {
+Object.defineProperty( exports.oFile.prototype, 'toonboomPath', {
   get: function(){
     var _path = this._path;
     if (!this.$.scene.online) return _path;
@@ -632,7 +632,7 @@ Object.defineProperty( $.oFile.prototype, 'toonboomPath', {
  *
  * @return: { string }                      The contents of the file.
  */
-$.oFile.prototype.read = function() {
+exports.oFile.prototype.read = function() {
   var file = new File(this.path);
 
   try {
@@ -654,7 +654,7 @@ $.oFile.prototype.read = function() {
  * @param   {string}   content               Content to write to the file.
  * @param   {bool}     [append=false]        Whether to append to the file.
  */
-$.oFile.prototype.write = function(content, append){
+exports.oFile.prototype.write = function(content, append){
     if (typeof append === 'undefined') var append = false
 
     var file = new File(this.path);
@@ -678,10 +678,10 @@ $.oFile.prototype.write = function(content, append){
  *
  * @return: { bool }                           The result of the move.
  */
-$.oFile.prototype.move = function( newPath, overwrite ){
+exports.oFile.prototype.move = function( newPath, overwrite ){
   if (typeof overwrite === 'undefined') var overwrite = false;
 
-  if(newPath instanceof this.$.oFile) newPath = newPath.path;
+  if(newPath instanceof exports.oFile) newPath = newPath.path;
 
   var _file = new PermanentFile(this.path);
   var _dest = new PermanentFile(newPath);
@@ -713,8 +713,8 @@ $.oFile.prototype.move = function( newPath, overwrite ){
  *
  * @return: { bool }                           The result of the move.
  */
-$.oFile.prototype.moveToFolder = function( folder, overwrite ){
-  if (folder instanceof this.$.oFolder) folder = folder.path;
+exports.oFile.prototype.moveToFolder = function( folder, overwrite ){
+  if (folder instanceof exports.oFolder) folder = folder.path;
   var _fileName = this.fullName;
 
   return this.move(folder+"/"+_fileName, overwrite)
@@ -728,7 +728,7 @@ $.oFile.prototype.moveToFolder = function( folder, overwrite ){
  *
  * @return: { bool }                           The result of the renaming.
  */
-$.oFile.prototype.rename = function( newName, overwrite){
+exports.oFile.prototype.rename = function( newName, overwrite){
   if (newName == this.name) return true;
   if (this.extension != "") newName += "."+this.extension;
   return this.move(this.folder.path+"/"+newName, overwrite);
@@ -744,13 +744,13 @@ $.oFile.prototype.rename = function( newName, overwrite){
  *
  * @return: { bool }                           The result of the copy.
  */
-$.oFile.prototype.copy = function( destfolder, copyName, overwrite){
+exports.oFile.prototype.copy = function( destfolder, copyName, overwrite){
     if (typeof overwrite === 'undefined') var overwrite = false;
     if (typeof copyName === 'undefined') var copyName = this.name;
     if (typeof destfolder === 'undefined') var destfolder = this.folder.path;
 
     var _fileName = this.fullName;
-    if(destfolder instanceof this.$.oFolder) destfolder = destfolder.path;
+    if(destfolder instanceof exports.oFolder) destfolder = destfolder.path;
 
     // remove extension from name in case user added it to the param
     copyName.replace ("."+this.extension, "");
@@ -778,7 +778,7 @@ $.oFile.prototype.copy = function( destfolder, copyName, overwrite){
  * Removes the file.
  * @return: { bool }                           The result of the removal.
  */
-$.oFile.prototype.remove = function(){
+exports.oFile.prototype.remove = function(){
     var _file = new PermanentFile(this.path)
     if (_file.exists()) return _file.remove()
 }
@@ -805,7 +805,7 @@ $.oFile.prototype.remove = function(){
  *   log (shortcuts[i].id)
  * }
  */
-$.oFile.prototype.parseAsXml = function(){
+exports.oFile.prototype.parseAsXml = function(){
   if (this.extension.toLowerCase() != "xml") return
 
   // build an object model representation of the contents of the XML by parsing it character by character
@@ -819,7 +819,7 @@ $.oFile.prototype.parseAsXml = function(){
  * Used in converting the file to a string value, provides the string-path.
  * @return  {string}   The file path's as a string.
  */
-$.oFile.prototype.toString = function(){
+exports.oFile.prototype.toString = function(){
     return this.path;
 }
 
@@ -847,7 +847,7 @@ $.oFile.prototype.toString = function(){
  * @property {string}  objectName
  * @property {$.oXml[]}  children
  */
-$.oXml = function (xmlString, objectName){
+exports.oXml = function (xmlString, objectName){
   if (typeof objectName === 'undefined') var objectName = "xmlDocument";
   this.objectName = objectName;
   this.children = [];

--- a/openHarmony/openHarmony_frame.js
+++ b/openHarmony/openHarmony_frame.js
@@ -83,10 +83,10 @@ exports.oFrame = function( frameNumber, oColumnObject, subColumns ){
 
   this.frameNumber = frameNumber;
 
-  if( oColumnObject instanceof $.oAttribute ){  //Direct access to an attribute, when not keyable. We still provide a frame access for consistency.  > MCNote ?????
+  if( oColumnObject instanceof this.$.oAttribute ){  //Direct access to an attribute, when not keyable. We still provide a frame access for consistency.  > MCNote ?????
     this.column = false;
     this.attributeObject = oColumnObject;
-  }else if( oColumnObject instanceof $.oColumn ){
+  }else if( oColumnObject instanceof this.$.oColumn ){
     this.column = oColumnObject;
 
     if (this.column && typeof subColumns === 'undefined'){

--- a/openHarmony/openHarmony_frame.js
+++ b/openHarmony/openHarmony_frame.js
@@ -78,7 +78,7 @@
  *
  * frames[1].value = 5;   // frame array values and frameNumbers are matched, so this sets the value of frame 1
  */
-$.oFrame = function( frameNumber, oColumnObject, subColumns ){
+exports.oFrame = function( frameNumber, oColumnObject, subColumns ){
   this._type = "frame";
 
   this.frameNumber = frameNumber;
@@ -109,7 +109,7 @@ $.oFrame = function( frameNumber, oColumnObject, subColumns ){
  * @type {object}
  * @todo Include setting values on column that don't have attributes linked?
  */
-Object.defineProperty($.oFrame.prototype, 'value', {
+Object.defineProperty(exports.oFrame.prototype, 'value', {
   get : function(){
     if (this.attributeObject){
       this.$.debug("getting value of frame "+this.frameNumber+" through attribute object : "+this.attributeObject.keyword, this.$.DEBUG_LEVEL.LOG);
@@ -158,7 +158,7 @@ Object.defineProperty($.oFrame.prototype, 'value', {
  * @name $.oFrame#isKeyframe
  * @type {bool}
  */
-Object.defineProperty($.oFrame.prototype, 'isKeyframe', {
+Object.defineProperty(exports.oFrame.prototype, 'isKeyframe', {
     get : function(){
       if( !this.column ) return true;
       if( this.frameNumber == 0 ) return false;  // frames array start at 0 but first index is not a real frame
@@ -221,7 +221,7 @@ Object.defineProperty($.oFrame.prototype, 'isKeyframe', {
  * @deprecated For case consistency, keyframe will never have a capital F
  * @type {bool}
  */
-Object.defineProperty($.oFrame.prototype, 'isKeyFrame', {
+Object.defineProperty(exports.oFrame.prototype, 'isKeyFrame', {
     get : function(){
       return this.isKeyframe;
     },
@@ -238,7 +238,7 @@ Object.defineProperty($.oFrame.prototype, 'isKeyFrame', {
  * @name $.oFrame#isKey
  * @type {bool}
  */
-Object.defineProperty($.oFrame.prototype, 'isKey', {
+Object.defineProperty(exports.oFrame.prototype, 'isKey', {
     get : function(){
       return this.isKeyframe;
     },
@@ -254,7 +254,7 @@ Object.defineProperty($.oFrame.prototype, 'isKey', {
  * @name $.oFrame#duration
  * @type {int}
  */
-Object.defineProperty($.oFrame.prototype, 'duration', {
+Object.defineProperty(exports.oFrame.prototype, 'duration', {
     get : function(){
         var _startFrame = this.startFrame;
         var _sceneLength = frame.numberOf()
@@ -282,7 +282,7 @@ Object.defineProperty($.oFrame.prototype, 'duration', {
  * @name $.oFrame#isBlank
  * @type {int}
  */
-Object.defineProperty($.oFrame.prototype, 'isBlank', {
+Object.defineProperty(exports.oFrame.prototype, 'isBlank', {
     get : function(){
       var col = this.column;
       if( !col ){
@@ -310,7 +310,7 @@ Object.defineProperty($.oFrame.prototype, 'isBlank', {
  * @type {int}
  * @readonly
  */
-Object.defineProperty($.oFrame.prototype, 'startFrame', {
+Object.defineProperty(exports.oFrame.prototype, 'startFrame', {
     get : function(){
       if( !this.column ){
         return 1;
@@ -333,7 +333,7 @@ Object.defineProperty($.oFrame.prototype, 'startFrame', {
  * @name $.oFrame#marker
  * @type {string}
  */
-Object.defineProperty($.oFrame.prototype, 'marker', {
+Object.defineProperty(exports.oFrame.prototype, 'marker', {
     get : function(){
         if( !this.column ){
           return "";
@@ -361,7 +361,7 @@ Object.defineProperty($.oFrame.prototype, 'marker', {
  * @name $.oFrame#keyframeIndex
  * @type {int}
  */
-Object.defineProperty($.oFrame.prototype, 'keyframeIndex', {
+Object.defineProperty(exports.oFrame.prototype, 'keyframeIndex', {
     get : function(){
         var _kf = this.column.getKeyframes().map(function(x){return x.frameNumber});
         var _kfIndex = _kf.indexOf(this.frameNumber);
@@ -375,7 +375,7 @@ Object.defineProperty($.oFrame.prototype, 'keyframeIndex', {
  * @name $.oFrame#keyframeLeft
  * @type {oFrame}
  */
-Object.defineProperty($.oFrame.prototype, 'keyframeLeft', {
+Object.defineProperty(exports.oFrame.prototype, 'keyframeLeft', {
     get : function(){
       return (new this.$.oFrame(this.startFrame, this.column));
     }
@@ -387,7 +387,7 @@ Object.defineProperty($.oFrame.prototype, 'keyframeLeft', {
  * @name $.oFrame#keyframeRight
  * @type {oFrame}
  */
-Object.defineProperty($.oFrame.prototype, 'keyframeRight', {
+Object.defineProperty(exports.oFrame.prototype, 'keyframeRight', {
     get : function(){
       return (new this.$.oFrame(this.startFrame+this.duration, this.column));
     }
@@ -399,7 +399,7 @@ Object.defineProperty($.oFrame.prototype, 'keyframeRight', {
  * @name $.oFrame#velocity
  * @type {oFrame}
  */
-Object.defineProperty($.oFrame.prototype, 'velocity', {
+Object.defineProperty(exports.oFrame.prototype, 'velocity', {
   get : function(){
     if (!this.column) return null;
     if (this.column.type != "3DPATH") return null;
@@ -430,7 +430,7 @@ Object.defineProperty($.oFrame.prototype, 'velocity', {
  * @name $.oFrame#ease
  * @type {oPoint/object}
  */
-Object.defineProperty($.oFrame.prototype, 'ease', {
+Object.defineProperty(exports.oFrame.prototype, 'ease', {
   get : function(){
     var _column = this.column;
     if (!_column) return null;
@@ -486,7 +486,7 @@ Object.defineProperty($.oFrame.prototype, 'ease', {
  * @name $.oFrame#easeIn
  * @type {oPoint/object}
  */
-Object.defineProperty($.oFrame.prototype, 'easeIn', {
+Object.defineProperty(exports.oFrame.prototype, 'easeIn', {
   get : function(){
     return this.ease.easeIn;
   },
@@ -505,7 +505,7 @@ Object.defineProperty($.oFrame.prototype, 'easeIn', {
  * @name $.oFrame#easeOut
  * @type {oPoint/object}
  */
-Object.defineProperty($.oFrame.prototype, 'easeOut', {
+Object.defineProperty(exports.oFrame.prototype, 'easeOut', {
   get : function(){
     return this.ease.easeOut;
   },
@@ -524,7 +524,7 @@ Object.defineProperty($.oFrame.prototype, 'easeOut', {
  * @name $.oFrame#continuity
  * @type {string}
  */
-Object.defineProperty($.oFrame.prototype, 'continuity', {
+Object.defineProperty(exports.oFrame.prototype, 'continuity', {
   get : function(){
     var _frame = this.keyframeLeft;    //Works on the left keyframe, in the event that this is not a keyframe itself.
 
@@ -546,7 +546,7 @@ Object.defineProperty($.oFrame.prototype, 'continuity', {
  * @name $.oFrame#constant
  * @type {string}
  */
-Object.defineProperty($.oFrame.prototype, 'constant', {
+Object.defineProperty(exports.oFrame.prototype, 'constant', {
   get : function(){
     var _frame = this.keyframeLeft;    //Works on the left keyframe, in the event that this is not a keyframe itself.
 
@@ -570,7 +570,7 @@ Object.defineProperty($.oFrame.prototype, 'constant', {
  * @name $.oFrame#tween
  * @type {string}
  */
-Object.defineProperty($.oFrame.prototype, 'tween', {
+Object.defineProperty(exports.oFrame.prototype, 'tween', {
   get : function(){
     return !this.constant;
   },
@@ -589,7 +589,7 @@ Object.defineProperty($.oFrame.prototype, 'tween', {
  * @param   {int}        duration              The duration to extend it to; if no duration specified, extends to the next available keyframe.
  * @param   {bool}       replace               Setting this to false will insert frames as opposed to overwrite existing ones. (not currently implemented)
  */
-$.oFrame.prototype.extend = function( duration, replace ){
+exports.oFrame.prototype.extend = function( duration, replace ){
     if (typeof replace === 'undefined') var replace = true;
     // setting this to false will insert frames as opposed to overwrite existing ones
 
@@ -616,6 +616,6 @@ $.oFrame.prototype.extend = function( duration, replace ){
     column.fillEmptyCels (this.column.name, _startFrame, duration + 1 );
 }
 
-$.oFrame.toString = function(){
+exports.oFrame.toString = function(){
   return '<oFrame object COLUMN:'+this.column.name+' frameNumber:'+this.frameNumber + ' value:'+this.value;
 }

--- a/openHarmony/openHarmony_list.js
+++ b/openHarmony/openHarmony_list.js
@@ -53,7 +53,7 @@
  * @param   {function}                 [setFunction=null]    The function run when setting an entry in the list.<br>In form <i>function( listItem, index, value ){ return resolvedValue; }</i> -- must return a resolved value. 
  * @param   {function}                 [sizeFunction=null]   The function run when resizing the list.<br>In form <i>function( listItem, length ){ }</i>
  */
-$.oList = function( initArray, startIndex, length, getFunction, setFunction, sizeFunction ){
+exports.oList = function( initArray, startIndex, length, getFunction, setFunction, sizeFunction ){
   if(typeof initArray == 'undefined') var initArray = [];
   if(typeof startIndex == 'undefined') var startIndex = 0;
   if(typeof getFunction == 'undefined') var getFunction = false;
@@ -118,7 +118,7 @@ $.oList = function( initArray, startIndex, length, getFunction, setFunction, siz
 }
 
 
-Object.defineProperty( $.oList.prototype, '_type', {
+Object.defineProperty( exports.oList.prototype, '_type', {
   enumerable : false, writable : false, configurable: false,
   value: 'dynList'
 });
@@ -129,7 +129,7 @@ Object.defineProperty( $.oList.prototype, '_type', {
  * @name $.oList#createGettersSetters
  * @private
  */
-Object.defineProperty($.oList.prototype, 'createGettersSetters', {
+Object.defineProperty(exports.oList.prototype, 'createGettersSetters', {
   enumerable : false,
   value: function(){
     { 
@@ -212,7 +212,7 @@ Object.defineProperty($.oList.prototype, 'createGettersSetters', {
  * @name $.oList#startIndex
  * @type {int}
  */
-Object.defineProperty( $.oList.prototype, 'startIndex', {
+Object.defineProperty( exports.oList.prototype, 'startIndex', {
   enumerable : false,
   get: function(){
     return this._startIndex;
@@ -233,7 +233,7 @@ Object.defineProperty( $.oList.prototype, 'startIndex', {
  * @function
  * @return {int}   The length of the list, considering the startIndex.
  */
-Object.defineProperty($.oList.prototype, 'length', {
+Object.defineProperty(exports.oList.prototype, 'length', {
   enumerable : false,
   get: function(){
     return this._length;
@@ -259,7 +259,7 @@ Object.defineProperty($.oList.prototype, 'length', {
  * @function
  * @return {object}   The first item in the list.
  */
-Object.defineProperty($.oList.prototype, 'first', {
+Object.defineProperty(exports.oList.prototype, 'first', {
   enumerable : false,
   value: function(){
     this.currentIndex = this.startIndex;
@@ -282,7 +282,7 @@ Object.defineProperty($.oList.prototype, 'first', {
  *   item = myList.next();   
  * }
  */
-Object.defineProperty($.oList.prototype, 'next', {
+Object.defineProperty(exports.oList.prototype, 'next', {
   enumerable : false,
   value: function(){
     this.currentIndex++;
@@ -302,7 +302,7 @@ Object.defineProperty($.oList.prototype, 'next', {
  * @name $.oList#lastIndex
  * @type {int}
  */
-Object.defineProperty($.oList.prototype, 'lastIndex', {
+Object.defineProperty(exports.oList.prototype, 'lastIndex', {
   enumerable : false,
   get: function(){
     return this.length - 1;
@@ -318,7 +318,7 @@ Object.defineProperty($.oList.prototype, 'lastIndex', {
  *
  * @return  {int}   Returns the new length of the oList.
  */
-Object.defineProperty($.oList.prototype, 'push', {
+Object.defineProperty(exports.oList.prototype, 'push', {
   enumerable : false,
   value : function( newElement ){
     var origLength = this.length;
@@ -335,7 +335,7 @@ Object.defineProperty($.oList.prototype, 'push', {
  * @function
  * @return  {int}   The item popped from the back of the array.
  */
-Object.defineProperty($.oList.prototype, 'pop', {
+Object.defineProperty(exports.oList.prototype, 'pop', {
   enumerable : false,
   value : function( ){
 
@@ -361,7 +361,7 @@ Object.defineProperty($.oList.prototype, 'pop', {
  *
  * @return  {$.oList}   The list represented as an array, filtered given the function.
  */
-Object.defineProperty($.oList.prototype, 'filterByFunction', {
+Object.defineProperty(exports.oList.prototype, 'filterByFunction', {
   enumerable : false,
   value : function( func ){
     var _results = [];
@@ -395,7 +395,7 @@ Object.defineProperty($.oList.prototype, 'filterByFunction', {
  * $.log(readNodes.extractProperty("name"))  // prints the names of the result
  *
  */
-Object.defineProperty($.oList.prototype, 'filterByProperty', {
+Object.defineProperty(exports.oList.prototype, 'filterByProperty', {
   enumerable : false,
   value : function(property, search){
     var _results = []
@@ -418,7 +418,7 @@ Object.defineProperty($.oList.prototype, 'filterByProperty', {
  *
  * @return  {$.oList}   The newly created oList object containing the property values.
  */
-Object.defineProperty($.oList.prototype, 'extractProperty', {
+Object.defineProperty(exports.oList.prototype, 'extractProperty', {
   enumerable : false,
   value : function(property){
     var _results = []
@@ -440,7 +440,7 @@ Object.defineProperty($.oList.prototype, 'extractProperty', {
  *
  * @return  {$.oList}   The sorted $oList.
  */
-Object.defineProperty($.oList.prototype, 'sortByProperty', {
+Object.defineProperty(exports.oList.prototype, 'sortByProperty', {
   enumerable : false,
   value : function( property, ascending ){
     if (typeof ascending === 'undefined') var ascending = true;
@@ -466,7 +466,7 @@ Object.defineProperty($.oList.prototype, 'sortByProperty', {
  *
  * @return  {$.oList}   The sorted $oList.
  */
-Object.defineProperty($.oList.prototype, 'sortByFunction', {
+Object.defineProperty(exports.oList.prototype, 'sortByFunction', {
   enumerable : false,
   value : function( func ){
     var _array = this.toArray();
@@ -485,7 +485,7 @@ Object.defineProperty($.oList.prototype, 'sortByFunction', {
  * @function
  * @return  {object[]}   The list represented as an array.
  */
-Object.defineProperty($.oList.prototype, 'toArray', {
+Object.defineProperty(exports.oList.prototype, 'toArray', {
   enumerable : false,
   value : function(){
     var _array = [];
@@ -506,7 +506,7 @@ Object.defineProperty($.oList.prototype, 'toArray', {
  * @function 
  * @type {string}
  */
-Object.defineProperty($.oList.prototype, 'toString', {
+Object.defineProperty(exports.oList.prototype, 'toString', {
   enumerable : false,
   value: function(){
     return this.toArray().join(",");

--- a/openHarmony/openHarmony_log.js
+++ b/openHarmony/openHarmony_log.js
@@ -1,0 +1,66 @@
+
+
+exports.debug_level = 0
+
+/**
+ * Enum to set the debug level of debug statements.
+ * @name    $#DEBUG_LEVEL
+ * @enum
+ */
+exports.DEBUG_LEVEL = {
+  'ERROR'   : 0,
+  'WARNING' : 1,
+  'LOG'     : 2
+}
+
+/**
+ * The standard debug that uses logic and level to write to the messagelog. Everything should just call this to write internally to a log in OpenHarmony.
+ * @function
+ * @name    $#debug
+ * @param   {obj}   obj            Description.
+ * @param   {int}   level          The debug level of the incoming message to log.
+ */
+exports.debug = function( obj, level ){
+  if( level > this.debug_level ) return;
+
+  try{
+    if (typeof obj !== 'object') throw new Error();
+    this.log(JSON.stringify(obj));
+  }catch(err){
+    this.log(obj);
+  }
+}
+
+
+/**
+ * Log the string to the MessageLog.
+ * @function
+ * @name    $#log
+ * @param {string}  str            Text to log.
+ */
+exports.log = function( str ){
+  MessageLog.trace( str );
+  System.println( str );
+}
+
+
+/**
+ * Log the object and its contents.
+ * @function
+ * @name    $#logObj
+ * @param   {object}   object            The object to log.
+ * @param   {int}      debugLevel        The debug level.
+ */
+exports.logObj = function( object ){
+  for (var i in object){
+    try {
+      if (typeof object[i] === "function") continue;
+      exports.log(i+' : '+object[i])
+      if (typeof object[i] == "Object"){
+        exports.log(' -> ')
+        exports.logObj(object[i])
+        exports.log(' ----- ')
+      }
+    }catch(error){}
+  }
+}

--- a/openHarmony/openHarmony_math.js
+++ b/openHarmony/openHarmony_math.js
@@ -38,8 +38,6 @@
 //////////////////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////////////
 
-
-
 //////////////////////////////////////
 //////////////////////////////////////
 //                                  //
@@ -64,7 +62,7 @@
  * @property     {float}           y                              Vertical coordinate
  * @property     {float}           z                              Depth Coordinate
  */
-$.oPoint = function(x, y, z){
+exports.oPoint = function(x, y, z){
     if (typeof z === 'undefined') var z = 0;
 
     this._type = "point";
@@ -78,7 +76,7 @@ $.oPoint = function(x, y, z){
  * @name $.oPoint#polarCoordinates
  * an object containing {angle (float), radius (float)} values that represents polar coordinates (angle in radians) for the point's x and y value (z not yet supported)
  */
-Object.defineProperty( $.oPoint.prototype, 'polarCoordinates', {
+Object.defineProperty( exports.oPoint.prototype, 'polarCoordinates', {
   get: function(){
     var _angle = Math.atan2(this.y, this.x)
     var _radius = Math.sqrt(this.x*this.x+this.y*this.y)
@@ -104,7 +102,7 @@ Object.defineProperty( $.oPoint.prototype, 'polarCoordinates', {
  *
  * @returns { $.oPoint }                   Returns self (for inline addition).
  */
-$.oPoint.prototype.translate = function( x, y, z){
+exports.oPoint.prototype.translate = function( x, y, z){
   if (typeof x === 'undefined') var x = 0;
   if (typeof y === 'undefined') var y = 0;
   if (typeof z === 'undefined') var z = 0;
@@ -124,7 +122,7 @@ $.oPoint.prototype.translate = function( x, y, z){
  *
  * @return: { $.oPoint }                   Returns self (for inline addition).
  */
- $.oPoint.prototype.add = function( x, y, z ){
+ exports.oPoint.prototype.add = function( x, y, z ){
   if (typeof x === 'undefined') var x = 0;
   if (typeof y === 'undefined') var y = 0;
   if (typeof z === 'undefined') var z = 0;
@@ -141,7 +139,7 @@ $.oPoint.prototype.translate = function( x, y, z){
  * @param {$.oPoint}     point            the other point to calculate the distance from.
  * @returns {float}
  */
-$.oPoint.prototype.distance = function ( point ){
+exports.oPoint.prototype.distance = function ( point ){
   var distanceX = point.x-this.x;
   var distanceY = point.y-this.y;
   var distanceZ = point.z-this.z;
@@ -154,7 +152,7 @@ $.oPoint.prototype.distance = function ( point ){
  * @param   {$.oPoint}       add_pt                The point to add to this point.
  * @returns { $.oPoint }                           Returns itself (for inline addition).
  */
-$.oPoint.prototype.pointAdd = function( add_pt ){
+exports.oPoint.prototype.pointAdd = function( add_pt ){
   this.x += add_pt.x;
   this.y += add_pt.y;
   this.z += add_pt.z;
@@ -167,7 +165,7 @@ $.oPoint.prototype.pointAdd = function( add_pt ){
  * @param {$.oPoint}   oPoint                The point to add to this point.
  * @returns {$.oPoint}
  */
-$.oPoint.prototype.addPoint = function( point ){
+exports.oPoint.prototype.addPoint = function( point ){
   var x = this.x + point.x;
   var y = this.y + point.y;
   var z = this.z + point.z;
@@ -181,7 +179,7 @@ $.oPoint.prototype.addPoint = function( point ){
  * @param   {$.oPoint}       sub_pt                The point to subtract to this point.
  * @returns { $.oPoint }                           Returns itself (for inline addition).
  */
-$.oPoint.prototype.pointSubtract = function( sub_pt ){
+exports.oPoint.prototype.pointSubtract = function( sub_pt ){
   this.x -= sub_pt.x;
   this.y -= sub_pt.y;
   this.z -= sub_pt.z;
@@ -195,7 +193,7 @@ $.oPoint.prototype.pointSubtract = function( sub_pt ){
  * @param {$.oPoint}   point                The point to subtract to this point.
  * @returns {$.oPoint} a new independant oPoint.
  */
-$.oPoint.prototype.subtractPoint = function( point ){
+exports.oPoint.prototype.subtractPoint = function( point ){
   var x = this.x - point.x;
   var y = this.y - point.y;
   var z = this.z - point.z;
@@ -209,7 +207,7 @@ $.oPoint.prototype.subtractPoint = function( point ){
  *
  * @returns { $.oPoint }                           Returns itself (for inline addition).
  */
-$.oPoint.prototype.multiply = function( float_val ){
+exports.oPoint.prototype.multiply = function( float_val ){
   this.x *= float_val;
   this.y *= float_val;
   this.z *= float_val;
@@ -223,7 +221,7 @@ $.oPoint.prototype.multiply = function( float_val ){
  *
  * @returns { $.oPoint }                           Returns itself (for inline addition).
  */
-$.oPoint.prototype.divide = function( float_val ){
+exports.oPoint.prototype.divide = function( float_val ){
   this.x /= float_val;
   this.y /= float_val;
   this.z /= float_val;
@@ -237,7 +235,7 @@ $.oPoint.prototype.divide = function( float_val ){
  *
  * @returns { $.oPoint }                           Returns the $.oPoint average of provided points.
  */
-$.oPoint.prototype.pointAverage = function( point_array ){
+exports.oPoint.prototype.pointAverage = function( point_array ){
   var _avg = new this.$.oPoint( 0.0, 0.0, 0.0 );
   for (var x=0; x<point_array.length; x++) {
     _avg.pointAdd(point_array[x]);
@@ -252,7 +250,7 @@ $.oPoint.prototype.pointAverage = function( point_array ){
  * Converts a Drawing point coordinate into a scene coordinate, as used by pegs (since drawings are 2D, z is untouched)
  * @returns {$.oPoint}
  */
-$.oPoint.prototype.convertToSceneCoordinates = function () {
+exports.oPoint.prototype.convertToSceneCoordinates = function () {
   return new this.$.oPoint(this.x/this.$.scene.fieldVectorResolutionX, this.y/this.$.scene.fieldVectorResolutionY, this.z);
 }
 
@@ -261,7 +259,7 @@ $.oPoint.prototype.convertToSceneCoordinates = function () {
  * Converts a scene coordinate point into a Drawing space coordinate, as used by Drawing tools and $.oShape (since drawings are 2D, z is untouched)
  * @returns {$.oPoint}
  */
-$.oPoint.prototype.convertToDrawingSpace = function () {
+exports.oPoint.prototype.convertToDrawingSpace = function () {
   return new this.$.oPoint(this.x * this.$.scene.fieldVectorResolutionX, this.y * this.$.scene.fieldVectorResolutionY, this.z);
 }
 
@@ -271,7 +269,7 @@ $.oPoint.prototype.convertToDrawingSpace = function () {
  * OpenGL units have a square aspect ratio and go from -1 to 1 vertically in the camera field.
  * @returns nothing
  */
-$.oPoint.prototype.convertToOpenGL = function(){
+exports.oPoint.prototype.convertToOpenGL = function(){
 
   var qpt = scene.toOGL( new Point3d( this.x, this.y, this.z ) );
 
@@ -286,7 +284,7 @@ $.oPoint.prototype.convertToOpenGL = function(){
  * Uses the scene settings to convert this as an OpenGL point into a Harmony worldspace point.
  * @returns nothing
  */
-$.oPoint.prototype.convertToWorldspace = function(){
+exports.oPoint.prototype.convertToWorldspace = function(){
 
   var qpt = scene.fromOGL( new Point3d( this.x, this.y, this.z ) );
 
@@ -304,7 +302,7 @@ $.oPoint.prototype.convertToWorldspace = function(){
  *
  * @return: { $.oPoint }                          The interpolated value.
  */
-$.oPoint.prototype.lerp = function( point, perc ){
+exports.oPoint.prototype.lerp = function( point, perc ){
   var delta = new this.$.oPoint( point.x, point.y, point.z );
 
   delta = delta.pointSubtract( this );
@@ -315,7 +313,7 @@ $.oPoint.prototype.lerp = function( point, perc ){
 }
 
 
-$.oPoint.prototype.toString = function(){
+exports.oPoint.prototype.toString = function(){
   return this._type+": {x:"+this.x+", y:"+this.y+", z:"+this.z+"}";
 }
 
@@ -346,7 +344,7 @@ $.oPoint.prototype.toString = function(){
  * @property      {float}       right                            right horizontal bound
  * @property      {float}       bottom                           bottom vertical bound
  */
-$.oBox = function( left, top, right, bottom ){
+exports.oBox = function( left, top, right, bottom ){
   this._type = "box";
 
   if (typeof top === 'undefined') var top = Infinity
@@ -366,7 +364,7 @@ $.oBox = function( left, top, right, bottom ){
  * @name $.oBox#isEmpty
  * @type {bool}
  */
-Object.defineProperty($.oBox.prototype, 'isEmpty', {
+Object.defineProperty(exports.oBox.prototype, 'isEmpty', {
   get : function(){
     return this.top == Infinity && this.left == Infinity && this.right == -Infinity && this.bottom == -Infinity;
   }
@@ -379,7 +377,7 @@ Object.defineProperty($.oBox.prototype, 'isEmpty', {
  * @name $.oBox#width
  * @type {float}
  */
-Object.defineProperty($.oBox.prototype, 'width', {
+Object.defineProperty(exports.oBox.prototype, 'width', {
   get : function(){
     return this.right - this.left + 1; //Inclusive size.
   }
@@ -391,7 +389,7 @@ Object.defineProperty($.oBox.prototype, 'width', {
  * @name $.oBox#height
  * @type {float}
  */
-Object.defineProperty($.oBox.prototype, 'height', {
+Object.defineProperty(exports.oBox.prototype, 'height', {
   get : function(){
     return this.bottom - this.top;
   }
@@ -403,7 +401,7 @@ Object.defineProperty($.oBox.prototype, 'height', {
  * @name $.oBox#center
  * @type {$.oPoint}
  */
-Object.defineProperty($.oBox.prototype, 'center', {
+Object.defineProperty(exports.oBox.prototype, 'center', {
   get : function(){
     return new this.$.oPoint(this.left+this.width/2, this.top+this.height/2);
   }
@@ -414,7 +412,7 @@ Object.defineProperty($.oBox.prototype, 'center', {
  * Adds the input box to the bounds of the current $.oBox.
  * @param   {$.oBox}       box                The $.oBox to include.
  */
-$.oBox.prototype.include = function(box){
+exports.oBox.prototype.include = function(box){
   if (box.left < this.left) this.left = box.left;
   if (box.top < this.top) this.top = box.top;
   if (box.right > this.right) this.right = box.right;
@@ -427,7 +425,7 @@ $.oBox.prototype.include = function(box){
  * @param   {$.oBox}       box                The $.oBox to check for.
  * @param   {bool}         [partial=false]    wether to accept partially contained boxes.
  */
-$.oBox.prototype.contains = function(box, partial){
+exports.oBox.prototype.contains = function(box, partial){
   if (typeof partial === 'undefined') var partial = false;
 
   var fitLeft = (box.left >= this.left);
@@ -447,7 +445,7 @@ $.oBox.prototype.contains = function(box, partial){
  * Adds the bounds of the nodes to the current $.oBox.
  * @param   {oNode[]}       oNodeArray                An array of nodes to include in the box.
  */
-$.oBox.prototype.includeNodes = function(oNodeArray){
+exports.oBox.prototype.includeNodes = function(oNodeArray){
   // convert to array if only one node is passed
   if (!Array.isArray(oNodeArray)) oNodeArray = [oNodeArray];
 
@@ -461,7 +459,7 @@ $.oBox.prototype.includeNodes = function(oNodeArray){
 /**
  * @private
  */
-$.oBox.prototype.toString = function(){
+exports.oBox.prototype.toString = function(){
   return "{top:"+this.top+", right:"+this.right+", bottom:"+this.bottom+", left:"+this.left+"}"
 }
 
@@ -483,10 +481,10 @@ $.oBox.prototype.toString = function(){
  * @classdesc The $.oMatrix is a subclass of the native Matrix4x4 object from Harmony. It has the same methods and properties plus the ones listed here.
  * @param {Matrix4x4} matrixObject a matrix object to initialize the instance from
  */
-$.oMatrix = function(matrixObject){
+exports.oMatrix = function(matrixObject){
   Matrix4x4.constructor.call(this);
   if (matrixObject){
-    log(matrixObject)
+    this.$.debug(matrixObject, this.$.DEBUG_LEVEL.DEBUG);
     this.m00 = matrixObject.m00;
     this.m01 = matrixObject.m01;
     this.m02 = matrixObject.m02;
@@ -505,7 +503,7 @@ $.oMatrix = function(matrixObject){
     this.m33 = matrixObject.m33;
   }
 }
-$.oMatrix.prototype = Object.create(Matrix4x4.prototype)
+exports.oMatrix.prototype = Object.create(Matrix4x4.prototype)
 
 
 /**
@@ -513,7 +511,7 @@ $.oMatrix.prototype = Object.create(Matrix4x4.prototype)
  * @name $.oMatrix#values
  * @type {Array}
  */
-Object.defineProperty($.oMatrix.prototype, "values", {
+Object.defineProperty(exports.oMatrix.prototype, "values", {
   get:function(){
     return [
       [this.m00, this.m01, this.m02, this.m03],
@@ -528,7 +526,7 @@ Object.defineProperty($.oMatrix.prototype, "values", {
 /**
  * @private
  */
-$.oMatrix.prototype.toString = function(){
+exports.oMatrix.prototype.toString = function(){
   return "< $.oMatrix object : \n"+this.values.join("\n")+">";
 }
 
@@ -552,7 +550,7 @@ $.oMatrix.prototype.toString = function(){
  * @param {float} y a y coordinate for this vector.
  * @param {float} [z=0] a z coordinate for this vector. If ommited, will be set to 0 and vector will be 2D.
  */
-$.oVector = function(x, y, z){
+exports.oVector = function(x, y, z){
   if (typeof z === "undefined" || isNaN(z)) var z = 0;
 
   // since Vector3d doesn't have a prototype, we need to cheat to subclass it.
@@ -565,7 +563,7 @@ $.oVector = function(x, y, z){
  * @name $.oVector#x
  * @type {float}
  */
-Object.defineProperty($.oVector.prototype, "x", {
+Object.defineProperty(exports.oVector.prototype, "x", {
   get: function(){
     return this._vector.x;
   },
@@ -580,7 +578,7 @@ Object.defineProperty($.oVector.prototype, "x", {
  * @name $.oVector#y
  * @type {float}
  */
-Object.defineProperty($.oVector.prototype, "y", {
+Object.defineProperty(exports.oVector.prototype, "y", {
   get: function(){
     return this._vector.y;
   },
@@ -595,7 +593,7 @@ Object.defineProperty($.oVector.prototype, "y", {
  * @name $.oVector#z
  * @type {float}
  */
-Object.defineProperty($.oVector.prototype, "z", {
+Object.defineProperty(exports.oVector.prototype, "z", {
   get: function(){
     return this._vector.z;
   },
@@ -611,7 +609,7 @@ Object.defineProperty($.oVector.prototype, "z", {
  * @type {float}
  * @readonly
  */
-Object.defineProperty($.oVector.prototype, "length", {
+Object.defineProperty(exports.oVector.prototype, "length", {
   get: function(){
     return this._vector.length();
   }
@@ -622,8 +620,8 @@ Object.defineProperty($.oVector.prototype, "length", {
  * @static
  * A function of the oVector class (not oVector objects) that gives a vector from two points.
  */
-$.oVector.fromPoints = function(pointA, pointB){
-  return new $.oVector(pointB.x-pointA.x, pointB.y-pointA.y, pointB.z-pointA.z);
+exports.oVector.fromPoints = function(pointA, pointB){
+  return new this.$.oVector(pointB.x-pointA.x, pointB.y-pointA.y, pointB.z-pointA.z);
 }
 
 
@@ -632,7 +630,7 @@ $.oVector.fromPoints = function(pointA, pointB){
  * @param {$.oVector} vector2
  * @returns {$.oVector} returns itself.
  */
-$.oVector.prototype.add = function (vector2){
+exports.oVector.prototype.add = function (vector2){
   this.x += vector2.x;
   this.y += vector2.y;
   this.z += vector2.z;
@@ -646,7 +644,7 @@ $.oVector.prototype.add = function (vector2){
  * @param {float} num
  * @returns {$.oVector} returns itself
  */
-$.oVector.prototype.multiply = function(num){
+exports.oVector.prototype.multiply = function(num){
   this.x = num*this.x;
   this.y = num*this.y;
   this.z = num*this.z;
@@ -660,7 +658,7 @@ $.oVector.prototype.multiply = function(num){
  * @param {$.oVector} vector2 a vector object.
  * @returns {float} the resultant vector from the dot product of the two vectors.
  */
-$.oVector.prototype.dot = function(vector2){
+exports.oVector.prototype.dot = function(vector2){
   var _dot = this._vector.dot(new Vector3d(vector2.x, vector2.y, vector2.z));
   return _dot;
 }
@@ -670,7 +668,7 @@ $.oVector.prototype.dot = function(vector2){
  * @param {$.oVector} vector2 a vector object.
  * @returns {$.oVector} the resultant vector from the dot product of the two vectors.
  */
-$.oVector.prototype.cross = function(vector2){
+exports.oVector.prototype.cross = function(vector2){
   var _cross = this._vector.cross(new Vector3d(vector2.x, vector2.y, vector2.z));
   return new this.$.oVector(_cross.x, _cross.y, _cross.z);
 }
@@ -680,7 +678,7 @@ $.oVector.prototype.cross = function(vector2){
  * @param {$.oVector} vector2 a vector object.
  * @returns {$.oVector} the resultant vector from the projection of the current vector.
  */
-$.oVector.prototype.project = function(vector2){
+exports.oVector.prototype.project = function(vector2){
   var _projection = this._vector.project(new Vector3d(vector2.x, vector2.y, vector2.z));
   return new this.$.oVector(_projection.x, _projection.y, _projection.z);
 }
@@ -689,7 +687,7 @@ $.oVector.prototype.project = function(vector2){
  * Normalize the vector.
  * @returns {$.oVector} returns itself after normalization.
  */
-$.oVector.prototype.normalize = function(){
+exports.oVector.prototype.normalize = function(){
   this._vector.normalize();
   return this;
 }
@@ -701,7 +699,7 @@ $.oVector.prototype.normalize = function(){
  * @type {float}
  * @readonly
  */
-Object.defineProperty($.oVector.prototype, "angle", {
+Object.defineProperty(exports.oVector.prototype, "angle", {
   get: function(){
     return Math.atan2(this.y, this.x);
   }
@@ -714,7 +712,7 @@ Object.defineProperty($.oVector.prototype, "angle", {
  * @type {float}
  * @readonly
  */
-Object.defineProperty($.oVector.prototype, "degreesAngle", {
+Object.defineProperty(exports.oVector.prototype, "degreesAngle", {
   get: function(){
     return this.angle * (180 / Math.PI);
   }
@@ -724,7 +722,7 @@ Object.defineProperty($.oVector.prototype, "degreesAngle", {
 /**
  * @private
  */
-$.oVector.prototype.toString = function(){
+exports.oVector.prototype.toString = function(){
   return "<$.oVector ["+this.x+", "+this.y+", "+this.z+"]>";
 }
 

--- a/openHarmony/openHarmony_metadata.js
+++ b/openHarmony/openHarmony_metadata.js
@@ -62,7 +62,7 @@
  * metadata.create( "mySceneMetadataName", {"ref":"thisReferenceValue"} );
  * metadata["mySceneMetadataName"]; //Provides: {"ref":"thisReferenceValue"}
  */
-$.oMetadata = function( source ){
+exports.oMetadata = function( source ){
   this._type             = "metadata";
   if( !source ){ source = 'scene'; }
   this.source = source;
@@ -79,7 +79,7 @@ $.oMetadata = function( source ){
  * @name $.oMetadata#refresh
  * @function
  */
-$.oMetadata.prototype.refresh = function(){
+exports.oMetadata.prototype.refresh = function(){
   
   //----------------------------
   //GETTER/SETTERS
@@ -203,7 +203,7 @@ $.oMetadata.prototype.refresh = function(){
  * @param   {string}                 name            The name of the new metadata to create.
  * @param   {object}                 val             The value of the new metadata created.
  */
-$.oMetadata.prototype.create = function( name, val ){
+exports.oMetadata.prototype.create = function( name, val ){
   var name = name.toLowerCase();
 
   if( this[ name ] ){
@@ -262,7 +262,7 @@ $.oMetadata.prototype.create = function( name, val ){
  * @name $.oMetadata#remove
  * @param   {string}                 name            The name of the metadata to remove.
  */
-$.oMetadata.prototype.remove = function( name ){
+exports.oMetadata.prototype.remove = function( name ){
   var name = name.toLowerCase();
   if( !this.hasOwnProperty( name ) ){ return true; }
   

--- a/openHarmony/openHarmony_misc.js
+++ b/openHarmony/openHarmony_misc.js
@@ -57,7 +57,7 @@
  * The $.oUtils helper class -- providing generic utilities. Doesn't need instanciation.
  * @classdesc  $.oUtils utility Class
  */
-$.oUtils = function(){
+exports.oUtils = function(){
     this._type = "utils";
 }
 
@@ -67,7 +67,7 @@ $.oUtils = function(){
  * @param   {string}   str2
  * @returns {string} the found string
  */
-$.oUtils.longestCommonSubstring = function( str1, str2 ){
+exports.oUtils.longestCommonSubstring = function( str1, str2 ){
 	if (!str1 || !str2)
 		return {
 			length: 0,

--- a/openHarmony/openHarmony_network.js
+++ b/openHarmony/openHarmony_network.js
@@ -56,7 +56,7 @@
  * @param   {dom}                  $         The connection back to the DOM.
  *
  */
-$.oNetwork = function( ){
+exports.oNetwork = function( ){
     //Expect a path for CURL.
     var avail_paths = [ 
                         "c:\\Windows\\System32\\curl.exe"
@@ -89,7 +89,7 @@ $.oNetwork = function( ){
  *  
  * @return: {string/object}       The resulting object/string from the query -- otherwise a bool as false when an error occured..
  */
-$.oNetwork.prototype.webQuery = function ( address, callback_func, use_json ){
+exports.oNetwork.prototype.webQuery = function ( address, callback_func, use_json ){
   if (typeof callback_func === 'undefined') var callback_func = false;
   if (typeof use_json === 'undefined') var use_json = false;
   
@@ -274,7 +274,7 @@ $.oNetwork.prototype.webQuery = function ( address, callback_func, use_json ){
  *  
  * @return: {string/object}       The resulting object/string from the query -- otherwise a bool as false when an error occured..
  */
-$.oNetwork.prototype.downloadSingle = function ( address, path, replace ){
+exports.oNetwork.prototype.downloadSingle = function ( address, path, replace ){
   if (typeof replace === 'undefined') var replace = false;
   
   try{
@@ -316,7 +316,7 @@ $.oNetwork.prototype.downloadSingle = function ( address, path, replace ){
  *  
  * @return: {bool[]}       The results of the download, for each file in the instruction bool[]
  */
-$.oNetwork.prototype.downloadMulti = function ( address_path, replace ){
+exports.oNetwork.prototype.downloadMulti = function ( address_path, replace ){
   if (typeof replace === 'undefined') var replace = false;
   
   var progress = new QProgressDialog();

--- a/openHarmony/openHarmony_node.js
+++ b/openHarmony/openHarmony_node.js
@@ -99,7 +99,7 @@ include(specialFolders.userScripts+"/TB_orderNetworkUp.js");       // for older 
  *
  * var attributes = myNode.attributes;
  */
-$.oNode = function( path, oSceneObject ){
+exports.oNode = function( path, oSceneObject ){
   var instance = this.$.getInstanceFromCache.call(this, path);
   if (instance) return instance;
 
@@ -116,7 +116,7 @@ $.oNode = function( path, oSceneObject ){
  * Initialize the attribute cache.
  * @private
  */
-$.oNode.prototype.attributesBuildCache = function (){
+exports.oNode.prototype.attributesBuildCache = function (){
   //Cache time can be used at later times, to check for auto-rebuild of caches. Not yet implemented.
   this._cacheTime = (new Date()).getTime();
 
@@ -139,7 +139,8 @@ $.oNode.prototype.attributesBuildCache = function (){
  * Private function to create attributes setters and getters as properties of the node
  * @private
  */
-$.oNode.prototype.setAttrGetterSetter = function (attr, context, oNodeObject){
+
+exports.oNode.prototype.setAttrGetterSetter = function (attr, context, oNodeObject){
     if (typeof context === 'undefined') context = this;
     // this.$.debug("Setting getter setters for attribute: "+attr.keyword+" of node: "+this.name, this.$.DEBUG_LEVEL.DEBUG)
 
@@ -219,7 +220,7 @@ $.oNode.prototype.setAttrGetterSetter = function (attr, context, oNodeObject){
  * @readonly
  * @type {string}
  */
-Object.defineProperty($.oNode.prototype, 'fullPath', {
+Object.defineProperty(exports.oNode.prototype, 'fullPath', {
     get : function( ){
       return this._path;
     }
@@ -233,7 +234,7 @@ Object.defineProperty($.oNode.prototype, 'fullPath', {
  * @type {string}
  * @readonly
  */
-Object.defineProperty($.oNode.prototype, 'path', {
+Object.defineProperty(exports.oNode.prototype, 'path', {
     get : function( ){
       return this._path;
     }
@@ -246,7 +247,7 @@ Object.defineProperty($.oNode.prototype, 'path', {
  * @readonly
  * @type {string}
  */
-Object.defineProperty( $.oNode.prototype, 'type', {
+Object.defineProperty( exports.oNode.prototype, 'type', {
     get : function( ){
       return node.type( this.path );
     }
@@ -260,7 +261,7 @@ Object.defineProperty( $.oNode.prototype, 'type', {
  * @deprecated check if the node is an instance of oGroupNode instead
  * @type {bool}
  */
-Object.defineProperty($.oNode.prototype, 'isGroup', {
+Object.defineProperty(exports.oNode.prototype, 'isGroup', {
     get : function( ){
       if( this.root ){
         //in a sense, its a group.
@@ -279,7 +280,7 @@ Object.defineProperty($.oNode.prototype, 'isGroup', {
  * @readonly
  * @type {$.oNode[]}
  */
-Object.defineProperty($.oNode.prototype, 'children', {
+Object.defineProperty(exports.oNode.prototype, 'children', {
     get : function( ){
       if( !this.isGroup ){ return []; }
 
@@ -305,7 +306,7 @@ Object.defineProperty($.oNode.prototype, 'children', {
  * @type {bool}
  * @readonly
  */
-Object.defineProperty($.oNode.prototype, 'exists', {
+Object.defineProperty(exports.oNode.prototype, 'exists', {
     get : function(){
       if( this.type ){
         return true;
@@ -321,7 +322,7 @@ Object.defineProperty($.oNode.prototype, 'exists', {
  * @name $.oNode#selected
  * @type {bool}
  */
-Object.defineProperty($.oNode.prototype, 'selected', {
+Object.defineProperty(exports.oNode.prototype, 'selected', {
     get : function(){
       return selection.selectedNodes().indexOf(this.path) != -1;
     },
@@ -343,7 +344,7 @@ Object.defineProperty($.oNode.prototype, 'selected', {
  * @name $.oNode#name
  * @type {string}
  */
-Object.defineProperty($.oNode.prototype, 'name', {
+Object.defineProperty(exports.oNode.prototype, 'name', {
   get : function(){
      return node.getName(this.path);
   },
@@ -368,7 +369,7 @@ Object.defineProperty($.oNode.prototype, 'name', {
  * @name $.oNode#nodeColor
  * @type {$.oColorValue}
  */
-Object.defineProperty($.oNode.prototype, 'nodeColor', {
+Object.defineProperty(exports.oNode.prototype, 'nodeColor', {
   get : function(){
     var _color = node.getColor(this.path);
     return new $.oColorValue({r:_color.r, g:_color.g, b:_color.b, a:_color.a});
@@ -385,7 +386,7 @@ Object.defineProperty($.oNode.prototype, 'nodeColor', {
  * @readonly
  * @type {oGroupNode}
  */
-Object.defineProperty($.oNode.prototype, 'group', {
+Object.defineProperty(exports.oNode.prototype, 'group', {
     get : function(){
          return this.scene.getNodeByPath( node.parentNode(this.path) )
     }
@@ -398,7 +399,7 @@ Object.defineProperty($.oNode.prototype, 'group', {
  * @readonly
  * @type {$.oNode}
  */
-Object.defineProperty( $.oNode.prototype, 'parent', {
+Object.defineProperty( exports.oNode.prototype, 'parent', {
     get : function(){
       if( this.root ){ return false; }
 
@@ -412,7 +413,7 @@ Object.defineProperty( $.oNode.prototype, 'parent', {
  * @name $.oNode#enabled
  * @type {bool}
  */
-Object.defineProperty($.oNode.prototype, 'enabled', {
+Object.defineProperty(exports.oNode.prototype, 'enabled', {
     get : function(){
          return node.getEnable(this.path)
     },
@@ -428,7 +429,7 @@ Object.defineProperty($.oNode.prototype, 'enabled', {
  * @name $.oNode#locked
  * @type {bool}
  */
-Object.defineProperty($.oNode.prototype, 'locked', {
+Object.defineProperty(exports.oNode.prototype, 'locked', {
     get : function(){
          return node.getLocked(this.path)
     },
@@ -445,7 +446,7 @@ Object.defineProperty($.oNode.prototype, 'locked', {
  * @readonly
  * @type {bool}
  */
-Object.defineProperty($.oNode.prototype, 'isRoot', {
+Object.defineProperty(exports.oNode.prototype, 'isRoot', {
     get : function(){
          return this.path == "Top"
     }
@@ -459,7 +460,7 @@ Object.defineProperty($.oNode.prototype, 'isRoot', {
  * @readonly
  * @type {$.oBackdrop[]}
  */
- Object.defineProperty($.oNode.prototype, 'containingBackdrops', {
+ Object.defineProperty(exports.oNode.prototype, 'containingBackdrops', {
   get : function(){
     var _backdrops = this.parent.backdrops;
     var _path = this.path;
@@ -476,7 +477,7 @@ Object.defineProperty($.oNode.prototype, 'isRoot', {
  * @name $.oNode#nodePosition
  * @type {oPoint}
  */
-Object.defineProperty($.oNode.prototype, 'nodePosition', {
+Object.defineProperty(exports.oNode.prototype, 'nodePosition', {
     get : function(){
       var _z = 0.0;
       try{ _z = node.coordZ(this.path); } catch( err ){this.$.debug("setting coordZ not implemented in Harmony versions before 17.", this.$.DEBUG_LEVEL.ERROR)}
@@ -494,7 +495,7 @@ Object.defineProperty($.oNode.prototype, 'nodePosition', {
  * @name $.oNode#x
  * @type {float}
  */
-Object.defineProperty($.oNode.prototype, 'x', {
+Object.defineProperty(exports.oNode.prototype, 'x', {
     get : function(){
          return node.coordX(this.path)
     },
@@ -511,7 +512,7 @@ Object.defineProperty($.oNode.prototype, 'x', {
  * @name $.oNode#y
  * @type {float}
  */
-Object.defineProperty($.oNode.prototype, 'y', {
+Object.defineProperty(exports.oNode.prototype, 'y', {
     get : function(){
          return node.coordY(this.path)
     },
@@ -528,7 +529,7 @@ Object.defineProperty($.oNode.prototype, 'y', {
  * @name $.oNode#z
  * @type {float}
  */
-Object.defineProperty($.oNode.prototype, 'z', {
+Object.defineProperty(exports.oNode.prototype, 'z', {
     get : function(){
         var _z = 0.0;
         try{ _z = node.coordZ(this.path); } catch( err ){ this.$.debug("setting coordZ not implemented in Harmony versions before 17.", this.$.DEBUG_LEVEL.ERROR)}
@@ -549,7 +550,7 @@ Object.defineProperty($.oNode.prototype, 'z', {
  * @readonly
  * @type {float}
  */
-Object.defineProperty($.oNode.prototype, 'width', {
+Object.defineProperty(exports.oNode.prototype, 'width', {
     get : function(){
          return node.width(this.path)
     }
@@ -563,7 +564,7 @@ Object.defineProperty($.oNode.prototype, 'width', {
  * @readonly
  * @type {float}
  */
-Object.defineProperty($.oNode.prototype, 'height', {
+Object.defineProperty(exports.oNode.prototype, 'height', {
     get : function(){
          return node.height(this.path)
     }
@@ -578,7 +579,7 @@ Object.defineProperty($.oNode.prototype, 'height', {
  * @deprecated returns $.oNodeLink instances but $.oLink is preferred. Use oNode.getInLinks() instead.
  * @type {$.oNodeLink[]}
  */
-Object.defineProperty($.oNode.prototype, 'inLinks', {
+Object.defineProperty(exports.oNode.prototype, 'inLinks', {
     get : function(){
         var nodeRef = this;
         var newList = new this.$.oList( [], 0, node.numberOfInputPorts(this.path),
@@ -598,7 +599,7 @@ Object.defineProperty($.oNode.prototype, 'inLinks', {
  * @type {$.oNode[]}
  * @deprecated returns $.oNodeLink instances but $.oLink is preferred. Use oNode.linkedInNodes instead.
 */
-Object.defineProperty($.oNode.prototype, 'inNodes', {
+Object.defineProperty(exports.oNode.prototype, 'inNodes', {
     get : function(){
         var _inNodes = [];
         var _inPorts = this.inPorts;
@@ -618,7 +619,7 @@ Object.defineProperty($.oNode.prototype, 'inNodes', {
  * @readonly
  * @type {int}
 */
-Object.defineProperty($.oNode.prototype, 'inPorts', {
+Object.defineProperty(exports.oNode.prototype, 'inPorts', {
   get : function(){
     return node.numberOfInputPorts(this.path);
   }
@@ -632,7 +633,7 @@ Object.defineProperty($.oNode.prototype, 'inPorts', {
  * @type {$.oNode[][]}
  * @deprecated  returns $.oNodeLink instances but $.oLink is preferred. Use oNode.linkedOutNodes instead.
 */
-Object.defineProperty($.oNode.prototype, 'outNodes', {
+Object.defineProperty(exports.oNode.prototype, 'outNodes', {
     get : function(){
         var _outNodes = [];
         var _outPorts = this.outPorts;
@@ -660,7 +661,7 @@ Object.defineProperty($.oNode.prototype, 'outNodes', {
  * @readonly
  * @type {int}
 */
-Object.defineProperty($.oNode.prototype, 'outPorts', {
+Object.defineProperty(exports.oNode.prototype, 'outPorts', {
   get : function(){
     return node.numberOfOutputPorts(this.path);
   }
@@ -674,7 +675,7 @@ Object.defineProperty($.oNode.prototype, 'outPorts', {
  * @type {$.oNodeLink[]}
  * @deprecated  returns $.oNodeLink instances but $.oLink is preferred. Use oNode.getOutLinks instead.
  */
-Object.defineProperty($.oNode.prototype, 'outLinks', {
+Object.defineProperty(exports.oNode.prototype, 'outLinks', {
     get : function(){
         var nodeRef = this;
 
@@ -705,7 +706,7 @@ Object.defineProperty($.oNode.prototype, 'outLinks', {
  * @readonly
  * @type {$.oNode[]}
  */
-Object.defineProperty($.oNode.prototype, 'linkedOutNodes', {
+Object.defineProperty(exports.oNode.prototype, 'linkedOutNodes', {
   get: function(){
     var _outNodes = this.getOutLinks().map(function(x){return x.inNode});
     return _outNodes;
@@ -719,7 +720,7 @@ Object.defineProperty($.oNode.prototype, 'linkedOutNodes', {
  * @readonly
  * @type {$.oNode[]}
  */
-Object.defineProperty($.oNode.prototype, 'linkedInNodes', {
+Object.defineProperty(exports.oNode.prototype, 'linkedInNodes', {
   get: function(){
     var _inNodes = this.getInLinks().map(function(x){return x.outNode});
     return _inNodes
@@ -734,7 +735,7 @@ Object.defineProperty($.oNode.prototype, 'linkedInNodes', {
  * @type {$.oNode[]}
  * @deprecated alias for deprecated oNode.inNodes property
 */
-Object.defineProperty($.oNode.prototype, 'ins', {
+Object.defineProperty(exports.oNode.prototype, 'ins', {
     get : function(){
       return this.inNodes;
     }
@@ -748,7 +749,7 @@ Object.defineProperty($.oNode.prototype, 'ins', {
  * @type {$.oNode[][]}
  * @deprecated alias for deprecated oNode.outNodes property
 */
-Object.defineProperty($.oNode.prototype, 'outs', {
+Object.defineProperty(exports.oNode.prototype, 'outs', {
     get : function(){
       return this.outNodes;
     }
@@ -776,7 +777,7 @@ Object.defineProperty($.oNode.prototype, 'outs', {
  *
  * var drawingAttribute = myNode.getAttributeByName("DRAWING.ELEMENT");
 */
-Object.defineProperty($.oNode.prototype, 'attributes', {
+Object.defineProperty(exports.oNode.prototype, 'attributes', {
   get : function(){
       return this._attributes_cached;
   }
@@ -789,7 +790,7 @@ Object.defineProperty($.oNode.prototype, 'attributes', {
  * @readonly
  * @type {oBox}
 */
-Object.defineProperty( $.oNode.prototype, 'bounds', {
+Object.defineProperty( exports.oNode.prototype, 'bounds', {
   get : function(){
     return new this.$.oBox(this.x, this.y, this.x+this.width, this.y+this.height);
   }
@@ -802,7 +803,7 @@ Object.defineProperty( $.oNode.prototype, 'bounds', {
  * @readonly
  * @type {oMatrix}
 */
-Object.defineProperty( $.oNode.prototype, 'matrix', {
+Object.defineProperty( exports.oNode.prototype, 'matrix', {
   get : function(){
     return this.getMatrixAtFrame(this.scene.currentFrame);
   }
@@ -815,7 +816,7 @@ Object.defineProperty( $.oNode.prototype, 'matrix', {
  * @readonly
  * @type {oColumn[]}
 */
-Object.defineProperty($.oNode.prototype, 'linkedColumns', {
+Object.defineProperty(exports.oNode.prototype, 'linkedColumns', {
   get : function(){
     var _attributes = this.attributes;
     var _columns = [];
@@ -835,7 +836,7 @@ Object.defineProperty($.oNode.prototype, 'linkedColumns', {
  * @readonly
  * @type {bool}
 */
-Object.defineProperty($.oNode.prototype, 'canCreateInPorts', {
+Object.defineProperty(exports.oNode.prototype, 'canCreateInPorts', {
   get : function(){
     return ["COMPOSITE",
             "GROUP",
@@ -849,7 +850,7 @@ Object.defineProperty($.oNode.prototype, 'canCreateInPorts', {
             "ParticleSystemComposite",
             "ParticleRegionComposite",
             "PointConstraintMulti",
-            "MULTIPORT_OUT"]
+            "MULTIPORT_OUT"]    // what if this was a property of nodeTypes?
             .indexOf(this.type) != -1;
   }
 })
@@ -861,10 +862,10 @@ Object.defineProperty($.oNode.prototype, 'canCreateInPorts', {
  * @readonly
  * @type {bool}
 */
-Object.defineProperty($.oNode.prototype, 'canCreateOutPorts', {
+Object.defineProperty(exports.oNode.prototype, 'canCreateOutPorts', {
   get : function(){
     return ["GROUP",
-            "MULTIPORT_IN"]
+            "MULTIPORT_IN"]     // what if this was a property of nodeTypes?
             .indexOf(this.type) != -1;
   }
 })
@@ -874,7 +875,7 @@ Object.defineProperty($.oNode.prototype, 'canCreateOutPorts', {
  * Returns the number of links connected to an in-port
  * @param   {int}      inPort      the number of the port to get links from.
  */
-$.oNode.prototype.getInLinksNumber = function(inPort){
+exports.oNode.prototype.getInLinksNumber = function(inPort){
   if (this.inPorts < inPort) return null;
   return node.isLinked(this.path, inPort)?1:0;
 }
@@ -885,7 +886,7 @@ $.oNode.prototype.getInLinksNumber = function(inPort){
  * @param   {int}      inPort      the number of the port to get links from.
  * @return  {$.oLink}  the oLink Object representing the link connected to the inport
  */
-$.oNode.prototype.getInLink = function(inPort){
+exports.oNode.prototype.getInLink = function(inPort){
   if (this.inPorts < inPort) return null;
   var _info = node.srcNodeInfo(this.path, inPort);
   // this.$.log(this.path+" "+inPort+" "+JSON.stringify(_info))
@@ -904,7 +905,7 @@ $.oNode.prototype.getInLink = function(inPort){
  * Returns all the valid oLink objects describing the links that are connected into this node.
  * @return {$.oLink[]}  An array of $.oLink objects.
  */
-$.oNode.prototype.getInLinks = function(){
+exports.oNode.prototype.getInLinks = function(){
   var _inPorts = this.inPorts;
   var _inLinks = [];
 
@@ -922,7 +923,7 @@ $.oNode.prototype.getInLinks = function(){
  * @param  {bool}  [createNew=true]  Whether to allow creation of new ports
  * @return {int} the port number that isn't connected
  */
-$.oNode.prototype.getFreeInPort = function(createNew){
+exports.oNode.prototype.getFreeInPort = function(createNew){
   if (typeof createNew === 'undefined') var createNew = true;
 
   var _inPorts = this.inPorts;
@@ -946,7 +947,7 @@ $.oNode.prototype.getFreeInPort = function(createNew){
  *
  * @return  {bool}    The result of the link, if successful.
  */
-$.oNode.prototype.linkInNode = function( nodeToLink, ownPort, destPort, createPorts){
+exports.oNode.prototype.linkInNode = function( nodeToLink, ownPort, destPort, createPorts){
   if (!(nodeToLink instanceof this.$.oNode)) throw new Error("Incorrect type for argument 'nodeToLink'. Must provide an $.oNode.")
 
   var _link = (new this.$.oLink(nodeToLink, this, destPort, ownPort)).getValidLink(createPorts, createPorts);
@@ -962,7 +963,7 @@ $.oNode.prototype.linkInNode = function( nodeToLink, ownPort, destPort, createPo
  * @param   {$.oNode}   oNodeObject            The node to link this one's inport to.
  * @return  {bool}    The result of the unlink.
  */
-$.oNode.prototype.unlinkInNode = function( oNodeObject ){
+exports.oNode.prototype.unlinkInNode = function( oNodeObject ){
 
   var _node = oNodeObject.path;
 
@@ -982,7 +983,7 @@ $.oNode.prototype.unlinkInNode = function( oNodeObject ){
  *
  * @return  {bool}    The result of the unlink, if successful.
  */
-$.oNode.prototype.unlinkInPort = function( inPort ){
+exports.oNode.prototype.unlinkInPort = function( inPort ){
   // Default values for optional parameters
   if (typeof inPort === 'undefined') inPort = 0;
 
@@ -995,7 +996,7 @@ $.oNode.prototype.unlinkInPort = function( inPort ){
  * @param   {int}        inPort      the number of the port to get the linked Node from.
  * @return  {$.oNode}                The node connected to this in-port
  */
-$.oNode.prototype.getLinkedInNode = function(inPort){
+exports.oNode.prototype.getLinkedInNode = function(inPort){
   if (this.inPorts < inPort) return null;
   return this.scene.getNodeByPath(node.srcNode(this.path, inPort));
 }
@@ -1006,7 +1007,7 @@ $.oNode.prototype.getLinkedInNode = function(inPort){
  * @param   {int}      outPort      the number of the port to get links from.
  * @return  {int}    the number of links
  */
-$.oNode.prototype.getOutLinksNumber = function(outPort){
+exports.oNode.prototype.getOutLinksNumber = function(outPort){
   if (this.outPorts < outPort) return null;
   return node.numberOfOutputLinks(this.path, outPort);
 }
@@ -1018,7 +1019,7 @@ $.oNode.prototype.getOutLinksNumber = function(outPort){
  * @param   {int}      [outLink]    the index of the link.
  * @return {$.oLink}   The link object describing the connection
  */
-$.oNode.prototype.getOutLink = function(outPort, outLink){
+exports.oNode.prototype.getOutLink = function(outPort, outLink){
   if (typeof outLink === 'undefined') var outLink = 0;
 
   if (this.outPorts < outPort) return null;
@@ -1038,7 +1039,7 @@ $.oNode.prototype.getOutLink = function(outPort, outLink){
  * Returns all the valid oLink objects describing the links that are coming out of this node.
  * @return {$.oLink[]}  An array of $.oLink objects.
  */
-$.oNode.prototype.getOutLinks = function(){
+exports.oNode.prototype.getOutLinks = function(){
   var _outPorts = this.outPorts;
   var _links = [];
 
@@ -1059,7 +1060,7 @@ $.oNode.prototype.getOutLinks = function(){
  * @param  {bool}  [createNew=false]  Whether to allow creation of new ports
  * @return {int} the port number that isn't connected
  */
-$.oNode.prototype.getFreeOutPort = function(createNew){
+exports.oNode.prototype.getFreeOutPort = function(createNew){
   if (typeof createNew === 'undefined') var createNew = false;
 
   var _outPorts = this.outPorts;
@@ -1080,7 +1081,7 @@ $.oNode.prototype.getFreeOutPort = function(createNew){
  * @param {bool} lookInsideGroups wether to consider the nodes inside connected groups
  * @returns {$.oNode} the found node
  */
- $.oNode.prototype.findFirstInNodeMatching = function(condition, lookInsideGroups){
+ exports.oNode.prototype.findFirstInNodeMatching = function(condition, lookInsideGroups){
   if (typeof lookInsideGroups === 'undefined') var lookInsideGroups = false;
 
   var _linkedNodes = this.linkedInNodes;
@@ -1103,7 +1104,7 @@ $.oNode.prototype.getFreeOutPort = function(createNew){
  * @param {bool} lookInsideGroups wether to consider the nodes inside connected groups
  * @returns {$.oNode} the found node
  */
- $.oNode.prototype.findFirstOutNodeMatching = function(condition, lookInsideGroups){
+ exports.oNode.prototype.findFirstOutNodeMatching = function(condition, lookInsideGroups){
   if (typeof lookInsideGroups === 'undefined') var lookInsideGroups = false;
 
   var _linkedNodes = this.linkedOutNodes;
@@ -1126,7 +1127,7 @@ $.oNode.prototype.getFreeOutPort = function(createNew){
  * @param {bool} lookInsideGroups wether to consider the nodes inside connected groups
  * @returns {$.oNode} the found node
  */
-$.oNode.prototype.findFirstInNodeOfType = function(type, lookInsideGroups){
+exports.oNode.prototype.findFirstInNodeOfType = function(type, lookInsideGroups){
   return this.findFirstInNodeMatching(function(x){return x.type == type});
 }
 
@@ -1136,7 +1137,7 @@ $.oNode.prototype.findFirstInNodeOfType = function(type, lookInsideGroups){
  * @param {bool} lookInsideGroups wether to consider the nodes inside connected groups
  * @returns {$.oNode} the found node
  */
-$.oNode.prototype.findFirstOutNodeOfType = function(type, lookInsideGroups){
+exports.oNode.prototype.findFirstOutNodeOfType = function(type, lookInsideGroups){
   return this.findFirstOutNodeMatching(function(x){return x.type == type});
 }
 
@@ -1147,7 +1148,7 @@ $.oNode.prototype.findFirstOutNodeOfType = function(type, lookInsideGroups){
  * @param {bool} lookInsideGroups wether to consider the nodes inside connected groups
  * @returns {$.oNode} the found node
  */
-$.oNode.prototype.findFirstInLinkOfType = function(type){
+exports.oNode.prototype.findFirstInLinkOfType = function(type){
   var _inNode = this.findFirstInNodeMatching(function(x){return x.type == type})
   if (_inNode) return new $.oLinkPath(_inNode, this);
   return null;
@@ -1160,7 +1161,7 @@ $.oNode.prototype.findFirstInLinkOfType = function(type){
  * @param {bool} lookInsideGroups wether to consider the nodes inside connected groups
  * @returns {$.oNode} the found node
  */
-$.oNode.prototype.findFirstOutLinkOfType = function(type){
+exports.oNode.prototype.findFirstOutLinkOfType = function(type){
   var _outNode = this.findFirstOutNodeMatching(function(x){return x.type == type})
   if (_outNode) return new $.oLinkPath(this, _outNode);
   return null;
@@ -1175,7 +1176,7 @@ $.oNode.prototype.findFirstOutLinkOfType = function(type){
  *
  * @return  {bool}    The result of the link, if successful.
  */
-$.oNode.prototype.linkOutNode = function(nodeToLink, ownPort, destPort, createPorts){
+exports.oNode.prototype.linkOutNode = function(nodeToLink, ownPort, destPort, createPorts){
   if (!(nodeToLink instanceof this.$.oNode)) throw new Error("Incorrect type for argument 'nodeToLink'. Must provide an $.oNode.")
 
   var _link = (new this.$.oLink(this, nodeToLink, ownPort, destPort)).getValidLink(createPorts, createPorts)
@@ -1192,7 +1193,7 @@ $.oNode.prototype.linkOutNode = function(nodeToLink, ownPort, destPort, createPo
  *
  * @return  {bool}    The result of the link, if successful.
  */
-$.oNode.prototype.unlinkOutNode = function( oNodeObject ){
+exports.oNode.prototype.unlinkOutNode = function( oNodeObject ){
   var _node = oNodeObject.path;
 
   var _links = this.getOutLinks();
@@ -1211,7 +1212,7 @@ $.oNode.prototype.unlinkOutNode = function( oNodeObject ){
  * @param   {int}      [outLink=0]  the index of the link.
  * @return  {$.oNode}   The node connected to this outPort and outLink
  */
-$.oNode.prototype.getLinkedOutNode = function(outPort, outLink){
+exports.oNode.prototype.getLinkedOutNode = function(outPort, outLink){
   if (typeof outLink == 'undefined') var outLink = 0;
   if (this.outPorts < outPort || this.getOutLinksNumber(outPort) < outLink) return null;
   return this.scene.getNodeByPath(node.dstNode(this.path, outPort, outLink));
@@ -1225,7 +1226,7 @@ $.oNode.prototype.getLinkedOutNode = function(outPort, outLink){
  *
  * @return  {bool}    The result of the unlink, if successful.
  */
-$.oNode.prototype.unlinkOutPort = function( outPort, outLink ){
+exports.oNode.prototype.unlinkOutPort = function( outPort, outLink ){
     // Default values for optional parameters
     if (typeof outLink === 'undefined') outLink = 0;
 
@@ -1249,7 +1250,7 @@ $.oNode.prototype.unlinkOutPort = function( outPort, outLink ){
  *
  * @return  {bool}    The result of the link, if successful.
  */
-$.oNode.prototype.insertInNode = function( inPort, oNodeObject, inPortTarget, outPortTarget ){
+exports.oNode.prototype.insertInNode = function( inPort, oNodeObject, inPortTarget, outPortTarget ){
     var _node = oNodeObject.path;
 
     //QScriptValue
@@ -1269,7 +1270,7 @@ $.oNode.prototype.insertInNode = function( inPort, oNodeObject, inPortTarget, ou
  * Moves the node into the specified group. This doesn't create any composite or links to the multiport nodes. The node will be unlinked.
  * @param   {oGroupNode}   group      the group node to move the node into.
  */
-$.oNode.prototype.moveToGroup = function(group){
+exports.oNode.prototype.moveToGroup = function(group){
   var _name = this.name;
   if (group instanceof oGroupNode) group = group.path;
 
@@ -1319,7 +1320,7 @@ $.oNode.prototype.moveToGroup = function(group){
  * @param {int} frameNumber
  * @returns {oMatrix}  the matrix object
  */
-$.oNode.prototype.getMatrixAtFrame = function (frameNumber){
+exports.oNode.prototype.getMatrixAtFrame = function (frameNumber){
   return new this.$.oMatrix(node.getMatrix(this.path, frameNumber));
 }
 
@@ -1330,7 +1331,7 @@ $.oNode.prototype.getMatrixAtFrame = function (frameNumber){
  *
  * @return  {int}    The index within that timeline.
  */
- $.oNode.prototype.getTimelineLayer = function(timeline){
+ exports.oNode.prototype.getTimelineLayer = function(timeline){
   if (typeof timeline === 'undefined') var timeline = this.$.scene.currentTimeline;
 
   var _nodeLayers = timeline.layers.map(function(x){return x.node.path});
@@ -1347,7 +1348,7 @@ $.oNode.prototype.getMatrixAtFrame = function (frameNumber){
  *
  * @return  {int}    The index within that timeline.
  */
-$.oNode.prototype.timelineIndex = function(timeline){
+exports.oNode.prototype.timelineIndex = function(timeline){
   if (typeof timeline === 'undefined') var timeline = this.$.scene.currentTimeline;
 
   var _nodes = timeline.compositionLayersList;
@@ -1362,7 +1363,7 @@ $.oNode.prototype.timelineIndex = function(timeline){
  *
  * @return  {$.oNode[]}    The subbnodes contained in the group.
  */
-$.oNode.prototype.subNodes = function(recurse){
+exports.oNode.prototype.subNodes = function(recurse){
     if (typeof recurse === 'undefined') recurse = false;
     var _nodes = node.subNodes(this.path);
     var _subNodes = [];
@@ -1384,7 +1385,7 @@ $.oNode.prototype.subNodes = function(recurse){
  *
  * @return  {oPoint}   The resulting position of the node.
  */
-$.oNode.prototype.centerAbove = function( oNodeArray, xOffset, yOffset ){
+exports.oNode.prototype.centerAbove = function( oNodeArray, xOffset, yOffset ){
   if (!oNodeArray) throw new Error ("An array of nodes to center node '"+this.name+"' above must be provided.")
 
   // Defaults for optional parameters
@@ -1413,7 +1414,7 @@ $.oNode.prototype.centerAbove = function( oNodeArray, xOffset, yOffset ){
  *
  * @return  {oPoint}   The resulting position of the node.
  */
-$.oNode.prototype.centerBelow = function( oNodeArray, xOffset, yOffset){
+exports.oNode.prototype.centerBelow = function( oNodeArray, xOffset, yOffset){
     if (!oNodeArray) throw new Error ("An array of nodes to center node '"+this.name+"' below must be provided.")
 
     // Defaults for optional parameters
@@ -1442,7 +1443,7 @@ $.oNode.prototype.centerBelow = function( oNodeArray, xOffset, yOffset){
  *
  * @return  {oPoint}   The resulting position of the node.
  */
-$.oNode.prototype.placeAtCenter = function( oNodeArray, xOffset, yOffset ){
+exports.oNode.prototype.placeAtCenter = function( oNodeArray, xOffset, yOffset ){
     // Defaults for optional parameters
     if (typeof xOffset === 'undefined') var xOffset = 0;
     if (typeof yOffset === 'undefined') var yOffset = 0;
@@ -1465,7 +1466,7 @@ $.oNode.prototype.placeAtCenter = function( oNodeArray, xOffset, yOffset ){
  * @param   {int}     [verticalSpacing=120]   optional: The spacing between two rows of nodes.
  * @param   {int}     [horizontalSpacing=40]   optional: The spacing between two nodes horizontally.
  */
-$.oNode.prototype.orderAboveNodes = function(verticalSpacing, horizontalSpacing){
+exports.oNode.prototype.orderAboveNodes = function(verticalSpacing, horizontalSpacing){
   if (typeof verticalSpacing === 'undefined') var verticalSpacing = 120;
   if (typeof horizontalSpacing === 'undefined') var horizontalSpacing = 40;
 
@@ -1602,7 +1603,7 @@ $.oNode.prototype.orderAboveNodes = function(verticalSpacing, horizontalSpacing)
  * @param   {string}    newName              The new name for the cloned module.
  * @param   {oPoint}    newPosition          The new position for the cloned module.
  */
-$.oNode.prototype.clone = function( newName, newPosition ){
+exports.oNode.prototype.clone = function( newName, newPosition ){
   // Defaults for optional parameters
   if (typeof newPosition === 'undefined') var newPosition = this.nodePosition;
   if (typeof newName === 'undefined') var newName = this.name+"_clone";
@@ -1633,7 +1634,7 @@ $.oNode.prototype.clone = function( newName, newPosition ){
  * @param   {string}    [newName]              The new name for the duplicated node.
  * @param   {oPoint}    [newPosition]          The new position for the duplicated node.
  */
-$.oNode.prototype.duplicate = function(newName, newPosition){
+exports.oNode.prototype.duplicate = function(newName, newPosition){
   if (typeof newPosition === 'undefined') var newPosition = this.nodePosition;
   if (typeof newName === 'undefined') var newName = this.name+"_duplicate";
 
@@ -1665,7 +1666,7 @@ $.oNode.prototype.duplicate = function(newName, newPosition){
  *
  * @return  {void}
  */
-$.oNode.prototype.remove = function( deleteColumns, deleteElements ){
+exports.oNode.prototype.remove = function( deleteColumns, deleteElements ){
   if (typeof deleteFrames === 'undefined') var deleteColumns = true;
   if (typeof deleteElements === 'undefined') var deleteElements = true;
 
@@ -1693,7 +1694,7 @@ $.oNode.prototype.remove = function( deleteColumns, deleteElements ){
  * @param   {string}    keyword                    The attribute keyword to search.
  * @return  {oAttribute}   The matched attribute object, given the keyword.
  */
-$.oNode.prototype.getAttributeByName = function( keyword ){
+exports.oNode.prototype.getAttributeByName = function( keyword ){
   keyword = keyword.toLowerCase();
   keyword = keyword.split(".");
 
@@ -1719,7 +1720,7 @@ $.oNode.prototype.getAttributeByName = function( keyword ){
  * Used in converting the node to a string value, provides the string-path.
  * @return  {string}   The node path's as a string.
  */
-$.oNode.prototype.toString = function(){
+exports.oNode.prototype.toString = function(){
     return this.path;
 }
 
@@ -1729,7 +1730,7 @@ $.oNode.prototype.toString = function(){
  * @param   {string}       columnName                    The column name to search.
  * @return  {oAttribute}   The matched attribute object, given the column name.
  */
-$.oNode.prototype.getAttributeByColumnName = function( columnName ){
+exports.oNode.prototype.getAttributeByColumnName = function( columnName ){
   // var attribs = [];
 
   //Initially check for cache.
@@ -1765,7 +1766,7 @@ $.oNode.prototype.getAttributeByColumnName = function( columnName ){
  * @private
  * @return  {object}   The column_name->attribute object LUT.  {colName: { "node":oNode, "column":oColumn } }
  */
-$.oNode.prototype.getAttributesColumnCache = function( obj_lut ){
+exports.oNode.prototype.getAttributesColumnCache = function( obj_lut ){
   if (typeof obj_lut === 'undefined') obj_lut = {};
 
   for( var n in this.attributes ){
@@ -1801,7 +1802,7 @@ $.oNode.prototype.getAttributesColumnCache = function( obj_lut ){
  *  var peg2     = $.scene.getNodeByPath( "Top/Group/Peg2" );
  *  var newLink  = peg1.addOutLink( peg2, 0, 0 );
  */
-$.oNode.prototype.addOutLink = function( nodeToLink, ownPort, destPort ){
+exports.oNode.prototype.addOutLink = function( nodeToLink, ownPort, destPort ){
   if (typeof ownPort == 'undefined') var ownPort = 0;
   if (typeof destPort == 'undefined') var destPort = 0;
 
@@ -1820,7 +1821,7 @@ $.oNode.prototype.addOutLink = function( nodeToLink, ownPort, destPort ){
  *
  * @return  {$.oAttribute}     The resulting attribute created.
  */
-$.oNode.prototype.createAttribute = function( attrName, type, displayName, linkable ){
+exports.oNode.prototype.createAttribute = function( attrName, type, displayName, linkable ){
   if( !attrName ){ return false; }
   attrName = attrName.toLowerCase();
 
@@ -1861,7 +1862,7 @@ $.oNode.prototype.createAttribute = function( attrName, type, displayName, linka
  *
  * @return  {bool}     The result of the removal.
  */
-$.oNode.prototype.removeAttribute = function( attrName ){
+exports.oNode.prototype.removeAttribute = function( attrName ){
   attrName = attrName.toLowerCase();
   return node.removeDynamicAttr( this.path, attrName );
 }
@@ -1872,7 +1873,7 @@ $.oNode.prototype.removeAttribute = function( attrName ){
  * @param   {$.oNode}   oNodeObject            The node to link this one's inport to.
  * @return  {bool}    The result of the unlink.
  */
-$.oNode.prototype.refreshAttributes = function( ){
+exports.oNode.prototype.refreshAttributes = function( ){
     // generate properties from node attributes to allow for dot notation access
     this.attributesBuildCache();
 
@@ -1908,15 +1909,15 @@ $.oNode.prototype.refreshAttributes = function( ){
  * @param   {string}         path                          Path to the node in the network.
  * @param   {oScene}         oSceneObject                  Access to the oScene object of the DOM.
  */
-$.oPegNode = function( path, oSceneObject ) {
+exports.oPegNode = function( path, oSceneObject ) {
     if (node.type(path) != 'PEG') throw "'path' parameter must point to a 'PEG' type node";
     var instance = this.$.oNode.call( this, path, oSceneObject );
     if (instance) return instance;
 
     this._type = 'pegNode';
 }
-$.oPegNode.prototype = Object.create( $.oNode.prototype );
-$.oPegNode.prototype.constructor = $.oPegNode;
+exports.oPegNode.prototype = Object.create( exports.oNode.prototype );
+exports.oPegNode.prototype.constructor = exports.oPegNode;
 
 
 
@@ -1959,7 +1960,7 @@ $.oPegNode.prototype.constructor = $.oPegNode;
  *
  * var myOtherNode = sceneRoot.addDrawingNode("Drawing2");
  */
-$.oDrawingNode = function(path, oSceneObject) {
+exports.oDrawingNode = function(path, oSceneObject) {
     // $.oDrawingNode can only represent a node of type 'READ'
     if (node.type(path) != 'READ') throw "'path' parameter must point to a 'READ' type node";
     var instance = this.$.oNode.call(this, path, oSceneObject);
@@ -1967,8 +1968,8 @@ $.oDrawingNode = function(path, oSceneObject) {
 
     this._type = 'drawingNode';
 }
-$.oDrawingNode.prototype = Object.create($.oNode.prototype);
-$.oDrawingNode.prototype.constructor = $.oDrawingNode;
+exports.oDrawingNode.prototype = Object.create(exports.oNode.prototype);
+exports.oDrawingNode.prototype.constructor = exports.oDrawingNode;
 
 
 /**
@@ -1976,7 +1977,7 @@ $.oDrawingNode.prototype.constructor = $.oDrawingNode;
  * @name $.oDrawingNode#element
  * @type {$.oElement}
  */
-Object.defineProperty($.oDrawingNode.prototype, "element", {
+Object.defineProperty(exports.oDrawingNode.prototype, "element", {
   get : function(){
     return this.timingColumn.element;
   },
@@ -1993,7 +1994,7 @@ Object.defineProperty($.oDrawingNode.prototype, "element", {
  * @name $.oDrawingNode.timingColumn
  * @type {$.oDrawingColumn}
  */
-Object.defineProperty($.oDrawingNode.prototype, "timingColumn", {
+Object.defineProperty(exports.oDrawingNode.prototype, "timingColumn", {
   get : function(){
     return this.attributes.drawing.element.column;
   },
@@ -2010,7 +2011,7 @@ Object.defineProperty($.oDrawingNode.prototype, "timingColumn", {
  * @name $.oDrawingNode#usedColorIds
  * @type {int[]}
  */
-Object.defineProperty($.oDrawingNode.prototype, "usedColorIds", {
+Object.defineProperty(exports.oDrawingNode.prototype, "usedColorIds", {
   get : function(){
     // this.$.log("used colors in node : "+this.name)
     var _drawings = this.element.drawings;
@@ -2033,7 +2034,7 @@ Object.defineProperty($.oDrawingNode.prototype, "usedColorIds", {
  * @name $.oDrawingNode#usedColors
  * @type {$.oColor[]}
  */
-Object.defineProperty($.oDrawingNode.prototype, "usedColors", {
+Object.defineProperty(exports.oDrawingNode.prototype, "usedColors", {
   get : function(){
     // get unique Color Ids
     var _ids = this.usedColorIds;
@@ -2086,7 +2087,7 @@ Object.defineProperty($.oDrawingNode.prototype, "usedColors", {
  * myNode.drawing.element = {frameNumber: 5, value: "10"}             // setting the value of the frame 5
  * myNode.drawing.element = {frameNumber: 6, value: timings[1].value} // setting the value to the same as one of the timings
  */
-Object.defineProperty($.oDrawingNode.prototype, "timings", {
+Object.defineProperty(exports.oDrawingNode.prototype, "timings", {
     get : function(){
         return this.attributes.drawing.element.getKeyframes();
     }
@@ -2098,7 +2099,7 @@ Object.defineProperty($.oDrawingNode.prototype, "timings", {
  * @name $.oDrawingNode#palettes
  * @type {$.oPalette[]}
  */
-Object.defineProperty($.oDrawingNode.prototype, "palettes", {
+Object.defineProperty(exports.oDrawingNode.prototype, "palettes", {
   get : function(){
     var _element = this.element;
     return _element.palettes;
@@ -2113,7 +2114,7 @@ Object.defineProperty($.oDrawingNode.prototype, "palettes", {
  * @param {int} frameNumber
  * @return {$.oDrawing}
  */
-$.oDrawingNode.prototype.getDrawingAtFrame = function(frameNumber){
+exports.oDrawingNode.prototype.getDrawingAtFrame = function(frameNumber){
   if (typeof frame === "undefined") var frame = this.$.scene.currentFrame;
 
   var _attribute = this.attributes.drawing.element
@@ -2125,7 +2126,7 @@ $.oDrawingNode.prototype.getDrawingAtFrame = function(frameNumber){
  * Gets the list of palettes containing colors used by a drawing node. This only gets palettes with the first occurence of the colors.
  * @return  {$.oPalette[]}   The palettes that contain the color IDs used by the drawings of the node.
  */
-$.oDrawingNode.prototype.getUsedPalettes = function(){
+exports.oDrawingNode.prototype.getUsedPalettes = function(){
   var _palettes = {};
   var _usedPalettes = [];
 
@@ -2147,7 +2148,7 @@ $.oDrawingNode.prototype.getUsedPalettes = function(){
  * Displays all the drawings from the node's element onto the timeline
  * @param {int} [framesPerDrawing=1]   The number of frames each drawing will be shown for
  */
-$.oDrawingNode.prototype.exposeAllDrawings = function(framesPerDrawing){
+exports.oDrawingNode.prototype.exposeAllDrawings = function(framesPerDrawing){
   if (typeof framesPerDrawing === 'undefined') var framesPerDrawing = 1;
 
   var _drawings = this.element.drawings;
@@ -2173,7 +2174,7 @@ $.oDrawingNode.prototype.exposeAllDrawings = function(framesPerDrawing){
  * @param {bool} [convertToTvg=false] If the filename isn't a tvg file, specify if you want it converted (this doesn't vectorize the drawing).
  * @return {$.oDrawing} the created drawing
  */
-$.oDrawingNode.prototype.addDrawing = function(atFrame, name, filename, convertToTvg){
+exports.oDrawingNode.prototype.addDrawing = function(atFrame, name, filename, convertToTvg){
   return this.element.addDrawing(atFrame, name, filename, convertToTvg);
 }
 
@@ -2183,7 +2184,7 @@ $.oDrawingNode.prototype.addDrawing = function(atFrame, name, filename, convertT
  * @param {$.oDrawing} drawing
  * @param {int} frameNum
  */
-$.oDrawingNode.prototype.showDrawingAtFrame = function(drawing, frameNum){
+exports.oDrawingNode.prototype.showDrawingAtFrame = function(drawing, frameNum){
   var _column = this.timingColumn;
   _column.setValue(drawing.name, frameNum);
 }
@@ -2196,7 +2197,7 @@ $.oDrawingNode.prototype.showDrawingAtFrame = function(drawing, frameNum){
  *
  * @return  {$.oPalette}   The linked element Palette.
  */
-$.oDrawingNode.prototype.linkPalette = function(oPaletteObject, index){
+exports.oDrawingNode.prototype.linkPalette = function(oPaletteObject, index){
   return this.element.linkPalette(oPaletteObject, index);
 }
 
@@ -2207,7 +2208,7 @@ $.oDrawingNode.prototype.linkPalette = function(oPaletteObject, index){
  *
  * @return {bool}          The success of the unlink operation.
  */
-$.oDrawingNode.prototype.unlinkPalette = function(oPaletteObject){
+exports.oDrawingNode.prototype.unlinkPalette = function(oPaletteObject){
   return this.element.unlinkPalette(oPaletteObject);
 }
 
@@ -2220,7 +2221,7 @@ $.oDrawingNode.prototype.unlinkPalette = function(oPaletteObject){
  * @param   {oPoint}    [newPosition]          The new position for the duplicated node.
  * @param   {bool}      [duplicateElement]     Wether to also duplicate the element.
  */
-$.oDrawingNode.prototype.duplicate = function(newName, newPosition, duplicateElement){
+exports.oDrawingNode.prototype.duplicate = function(newName, newPosition, duplicateElement){
   if (typeof newPosition === 'undefined') var newPosition = this.nodePosition;
   if (typeof newName === 'undefined') var newName = this.name+"_1";
   if (typeof duplicateElement === 'undefined') var duplicateElement = true;
@@ -2248,7 +2249,7 @@ $.oDrawingNode.prototype.duplicate = function(newName, newPosition, duplicateEle
  * @param {string}    [drawingName]       the drawing to import the updated bitmap into
  * @todo implement a memory of the source through metadata
  */
-$.oDrawingNode.prototype.update = function(sourcePath, drawingName){
+exports.oDrawingNode.prototype.update = function(sourcePath, drawingName){
   if (!this.element) return; // no element means nothing to update, import instead.
   if (typeof drawingName === 'undefined') var drawingName = this.element.drawings[0].name;
 
@@ -2263,7 +2264,7 @@ $.oDrawingNode.prototype.update = function(sourcePath, drawingName){
  * Extracts the position information on a drawing node, and applies it to a new peg instead.
  * @return  {$.oPegNode}   The created peg.
  */
-$.oDrawingNode.prototype.extractPeg = function(){
+exports.oDrawingNode.prototype.extractPeg = function(){
     var _drawingNode = this;
     var _peg = this.group.addNode("PEG", this.name+"-P");
     var _columns = _drawingNode.linkedColumns;
@@ -2306,7 +2307,7 @@ $.oDrawingNode.prototype.extractPeg = function(){
  *
  * @return  {oPoint[][]}   The contour curves.
  */
-$.oDrawingNode.prototype.getContourCurves = function( count, frame ){
+exports.oDrawingNode.prototype.getContourCurves = function( count, frame ){
 
   if (typeof frame === 'undefined') var frame = this.scene.currentFrame;
   if (typeof count === 'undefined') var count = 3;
@@ -2374,7 +2375,7 @@ $.oDrawingNode.prototype.getContourCurves = function( count, frame ){
  * $.log("names: " + myNode.names)                     // prints the list of names
  * $.log("indexOf 'B': " + myNode.names.indexOf("B"))  // can use methods from Array
  */
-$.oTransformSwitchNode = function( path, oSceneObject ) {
+exports.oTransformSwitchNode = function( path, oSceneObject ) {
   if (node.type(path) != 'TransformationSwitch') throw "'path' parameter ("+path+") must point to a 'TransformationSwitch' type node. Got: "+node.type(path);
   var instance = this.$.oNode.call( this, path, oSceneObject );
   if (instance) return instance;
@@ -2382,8 +2383,8 @@ $.oTransformSwitchNode = function( path, oSceneObject ) {
   this._type = 'transformSwitchNode';
   this.names = new this.$.oTransformNamesObject(this);
 }
-$.oTransformSwitchNode.prototype = Object.create( $.oNode.prototype );
-$.oTransformSwitchNode.prototype.constructor = $.oTransformSwitchNode;
+exports.oTransformSwitchNode.prototype = Object.create( exports.oNode.prototype );
+exports.oTransformSwitchNode.prototype.constructor = exports.oTransformSwitchNode;
 
 
 /**
@@ -2395,7 +2396,7 @@ $.oTransformSwitchNode.prototype.constructor = $.oTransformSwitchNode;
  * @param {$.oTransformSwitchNode} instance the transform Node instance using this object
  * @property {int} length the number of valid elements in the object.
  */
-$.oTransformNamesObject = function(transformSwitchNode){
+exports.oTransformNamesObject = function(transformSwitchNode){
   Object.defineProperty(this, "transformSwitchNode", {
     enumerable:false,
     get: function(){
@@ -2405,14 +2406,14 @@ $.oTransformNamesObject = function(transformSwitchNode){
 
   this.refresh();
 }
-$.oTransformNamesObject.prototype = Object.create(Array.prototype);
+exports.oTransformNamesObject.prototype = Object.create(Array.prototype);
 
 
 /**
  * creates a $.oTransformSwitch.names property with an index for each name to get/set the name value
  * @private
  */
-Object.defineProperty($.oTransformNamesObject.prototype, "createGetterSetter", {
+Object.defineProperty(exports.oTransformNamesObject.prototype, "createGetterSetter", {
   enumerable:false,
   value: function(index){
     var attrName = "transformation_" + (index+1);
@@ -2440,7 +2441,7 @@ Object.defineProperty($.oTransformNamesObject.prototype, "createGetterSetter", {
  * @name $.oTransformNamesObject#length
  * @type {int}
  */
- Object.defineProperty($.oTransformNamesObject.prototype, "length", {
+ Object.defineProperty(exports.oTransformNamesObject.prototype, "length", {
   enumerable:false,
   get: function(){
     return this.transformSwitchNode.transformationnames.size;
@@ -2452,7 +2453,7 @@ Object.defineProperty($.oTransformNamesObject.prototype, "createGetterSetter", {
  * A string representation of the names list
  * @private
  */
-Object.defineProperty($.oTransformNamesObject.prototype, "toString", {
+Object.defineProperty(exports.oTransformNamesObject.prototype, "toString", {
   enumerable:false,
   value: function(){
     return this.join(",");
@@ -2463,7 +2464,7 @@ Object.defineProperty($.oTransformNamesObject.prototype, "toString", {
 /**
  * @private
  */
-Object.defineProperty($.oTransformNamesObject.prototype, "refresh", {
+Object.defineProperty(exports.oTransformNamesObject.prototype, "refresh", {
   enumerable:false,
   value:function(){
     for (var i in this){
@@ -2479,7 +2480,7 @@ Object.defineProperty($.oTransformNamesObject.prototype, "refresh", {
 /**
  * @private
  */
-$.oTransformSwitchNode.prototype.refreshNames = function(){
+exports.oTransformSwitchNode.prototype.refreshNames = function(){
   this.refreshAttributes();
   this.names.refresh();
 }
@@ -2495,8 +2496,8 @@ $.oTransformSwitchNode.prototype.refreshNames = function(){
  *
  * @return  {bool}    The result of the link, if successful.
  */
-$.oTransformSwitchNode.prototype.linkInNode = function(nodeToLink, ownPort, destPort, createPorts){
-  this.$.oNode.prototype.linkInNode.apply(this, arguments);
+exports.oTransformSwitchNode.prototype.linkInNode = function(nodeToLink, ownPort, destPort, createPorts){
+  this.exports.oNode.prototype.linkInNode.apply(this, arguments);
   this.refreshNames()
 }
 
@@ -2505,8 +2506,8 @@ $.oTransformSwitchNode.prototype.linkInNode = function(nodeToLink, ownPort, dest
  * @param   {$.oNode}   oNodeObject            The node to link this one's inport to.
  * @return  {bool}    The result of the unlink. Refreshes attributes to update for the changes of connected transformation.
  */
-$.oTransformSwitchNode.prototype.unlinkInNode = function( oNodeObject ){
-  this.$.oNode.prototype.unlinkInNode.apply(this, arguments);
+exports.oTransformSwitchNode.prototype.unlinkInNode = function( oNodeObject ){
+  this.exports.oNode.prototype.unlinkInNode.apply(this, arguments);
   this.refreshNames()
 }
 
@@ -2530,7 +2531,7 @@ $.oTransformSwitchNode.prototype.unlinkInNode = function( oNodeObject ){
  * @param   {string}         path                          Path to the node in the network.
  * @param   {oScene}         oSceneObject                  Access to the oScene object of the DOM.
  */
- $.oColorOverrideNode = function(path, oSceneObject) {
+exports.oColorOverrideNode = function(path, oSceneObject) {
   // $.oDrawingNode can only represent a node of type 'READ'
   if (node.type(path) != 'COLOR_OVERRIDE_TVG') throw "'path' parameter must point to a 'COLOR_OVERRIDE_TVG' type node";
   var instance = this.$.oNode.call(this, path, oSceneObject);
@@ -2539,8 +2540,8 @@ $.oTransformSwitchNode.prototype.unlinkInNode = function( oNodeObject ){
   this._type = 'colorOverrideNode';
   this._coObject = node.getColorOverride(path)
 }
-$.oColorOverrideNode.prototype = Object.create($.oNode.prototype);
-$.oColorOverrideNode.prototype.constructor = $.oColorOverrideNode;
+exports.oColorOverrideNode.prototype = Object.create(exports.oNode.prototype);
+exports.oColorOverrideNode.prototype.constructor = exports.oColorOverrideNode;
 
 
 /**
@@ -2549,7 +2550,7 @@ $.oColorOverrideNode.prototype.constructor = $.oColorOverrideNode;
  * @type {$.oPalette[]}
  * @readonly
  */
-Object.defineProperty($.oColorOverrideNode.prototype, "palettes", {
+Object.defineProperty(exports.oColorOverrideNode.prototype, "palettes", {
   get: function(){
     this.$.debug("getting palettes", this.$.DEBUG_LEVEL.LOG)
     if (!this._palettes){
@@ -2571,7 +2572,7 @@ Object.defineProperty($.oColorOverrideNode.prototype, "palettes", {
  * Add a new palette to the palette list (for now, only supports scene palettes)
  * @param {$.oPalette} palette
 */
-$.oColorOverrideNode.prototype.addPalette = function(palette){
+exports.oColorOverrideNode.prototype.addPalette = function(palette){
   var _palettes = this.palettes // init palettes cache to add to it
 
   this._coObject.addPalette(palette.path.path);
@@ -2582,7 +2583,7 @@ $.oColorOverrideNode.prototype.addPalette = function(palette){
  * Removes a palette to the palette list (for now, only supports scene palettes)
  * @param {$.oPalette} palette
  */
-$.oColorOverrideNode.prototype.removePalette = function(palette){
+exports.oColorOverrideNode.prototype.removePalette = function(palette){
   this._coObject.removePalette(palette.path.path);
 }
 
@@ -2622,7 +2623,7 @@ $.oColorOverrideNode.prototype.removePalette = function(palette){
  *
  * myGroup.centerAbove(sceneComposite);
  */
-$.oGroupNode = function(path, oSceneObject) {
+exports.oGroupNode = function(path, oSceneObject) {
     // $.oDrawingNode can only represent a node of type 'READ'
     if (node.type(path) != 'GROUP') throw "'path' parameter must point to a 'GROUP' type node";
     var instance = this.$.oNode.call(this, path, oSceneObject);
@@ -2630,8 +2631,8 @@ $.oGroupNode = function(path, oSceneObject) {
 
     this._type = 'groupNode';
 }
-$.oGroupNode.prototype = Object.create($.oNode.prototype);
-$.oGroupNode.prototype.constructor = $.oGroupNode;
+exports.oGroupNode.prototype = Object.create(exports.oNode.prototype);
+exports.oGroupNode.prototype.constructor = exports.oGroupNode;
 
 /**
  * The multiport in node of the group. If one doesn't exist, it will be created.
@@ -2639,7 +2640,7 @@ $.oGroupNode.prototype.constructor = $.oGroupNode;
  * @readonly
  * @type {$.oNode}
  */
-Object.defineProperty($.oGroupNode.prototype, "multiportIn", {
+Object.defineProperty(exports.oGroupNode.prototype, "multiportIn", {
     get : function(){
         if (this.isRoot) return null
         var _MPI = this.scene.getNodeByPath(node.getGroupInputModule(this.path, "Multiport-In", 0,-100,0),this.scene)
@@ -2654,7 +2655,7 @@ Object.defineProperty($.oGroupNode.prototype, "multiportIn", {
  * @readonly
  * @type {$.oNode}
  */
-Object.defineProperty($.oGroupNode.prototype, "multiportOut", {
+Object.defineProperty(exports.oGroupNode.prototype, "multiportOut", {
     get : function(){
         if (this.isRoot) return null
         var _MPO = this.scene.getNodeByPath(node.getGroupOutputModule(this.path, "Multiport-Out", 0, 100,0),this.scene)
@@ -2668,7 +2669,7 @@ Object.defineProperty($.oGroupNode.prototype, "multiportOut", {
  * @readonly
  * @type {$.oNode[]}
  */
-Object.defineProperty($.oGroupNode.prototype, "nodes", {
+Object.defineProperty(exports.oGroupNode.prototype, "nodes", {
   get : function() {
     var _path = this.path;
     var _nodes = node.subNodes(_path);
@@ -2685,7 +2686,7 @@ Object.defineProperty($.oGroupNode.prototype, "nodes", {
  * @readonly
  * @type {$.oNode[]}
  */
-Object.defineProperty($.oGroupNode.prototype, "nodesNoMultiport", {
+Object.defineProperty(exports.oGroupNode.prototype, "nodesNoMultiport", {
   get : function() {
     return this.nodes.filter(function(x){return x.type != "MULTIPORT_IN" && x.type != "MULTIPORT_OUT"})
   }
@@ -2699,7 +2700,7 @@ Object.defineProperty($.oGroupNode.prototype, "nodesNoMultiport", {
  * @readonly
  * @type {$.oBackdrop[]}
  */
-Object.defineProperty($.oGroupNode.prototype, "backdrops", {
+Object.defineProperty(exports.oGroupNode.prototype, "backdrops", {
   get : function() {
     var _path = this.path;
     var _backdropObjects = Backdrop.backdrops(this.path);
@@ -2716,7 +2717,7 @@ Object.defineProperty($.oGroupNode.prototype, "backdrops", {
  *
  * @return  {$.oNode}     The node, or null if can't be found.
  */
-$.oGroupNode.prototype.getNodeByName = function(name){
+exports.oGroupNode.prototype.getNodeByName = function(name){
   var _path = this.path+"/"+name;
 
   return this.scene.getNodeByPath(_path);
@@ -2731,7 +2732,7 @@ $.oGroupNode.prototype.getNodeByName = function(name){
  *
  * @return  {$.oNode[]}     The nodes found.
  */
-$.oGroupNode.prototype.getNodesByType = function(typeName, recurse){
+exports.oGroupNode.prototype.getNodesByType = function(typeName, recurse){
   if (typeof recurse === 'undefined') var recurse = false;
   return this.subNodes(recurse).filter(function(x){return x.type == typeName});
 }
@@ -2743,7 +2744,7 @@ $.oGroupNode.prototype.getNodesByType = function(typeName, recurse){
  *
  * @return  {$.oNode}     The node, or null if can't be found.
  */
-$.oGroupNode.prototype.$node = function(name){
+exports.oGroupNode.prototype.$node = function(name){
   return this.getNodeByName(name);
 }
 
@@ -2754,7 +2755,7 @@ $.oGroupNode.prototype.$node = function(name){
  *
  * @return  {$.oNode[]}   The nodes in the group
  */
-$.oGroupNode.prototype.subNodes = function(recurse){
+exports.oGroupNode.prototype.subNodes = function(recurse){
     if (typeof recurse === 'undefined') recurse = false;
 
     var _nodes = node.subNodes(this.path);
@@ -2776,7 +2777,7 @@ $.oGroupNode.prototype.subNodes = function(recurse){
  *
  * @return  {$.oNode[]}   The nodes in the group
  */
-$.oGroupNode.prototype.children = function(recurse){
+exports.oGroupNode.prototype.children = function(recurse){
   return this.subNodes(recurse);
 }
 
@@ -2789,7 +2790,7 @@ $.oGroupNode.prototype.children = function(recurse){
  *
  * @return  {int}   The number of the created port in case the port specified was not correct (for example larger than the current number of ports + 1)
  */
-$.oGroupNode.prototype.addInPort = function(portNum, type){
+exports.oGroupNode.prototype.addInPort = function(portNum, type){
   var _inPorts = this.inPorts;
 
   if (typeof portNum === 'undefined') var portNum = _inPorts;
@@ -2813,7 +2814,7 @@ $.oGroupNode.prototype.addInPort = function(portNum, type){
  *
  * @return  {int}   The number of the created port in case the port specified was not correct (for example larger than the current number of ports + 1)
  */
-$.oGroupNode.prototype.addOutPort = function(portNum, type){
+exports.oGroupNode.prototype.addOutPort = function(portNum, type){
   var _outPorts = this.outPorts;
 
   if (typeof portNum === 'undefined') var portNum = _outPorts;
@@ -2836,7 +2837,7 @@ $.oGroupNode.prototype.addOutPort = function(portNum, type){
  *
  * @return  {$.oNode[]}   The nodes in the group
  */
-$.oGroupNode.prototype.children = function(recurse){
+exports.oGroupNode.prototype.children = function(recurse){
   return this.subNodes(recurse);
 }
 
@@ -2846,7 +2847,7 @@ $.oGroupNode.prototype.children = function(recurse){
  * Sorts out the node view inside the group
  * @param   {bool}    [recurse=false]             Whether to recurse the groups within the groups.
  */
-$.oGroupNode.prototype.orderNodeView = function(recurse){
+exports.oGroupNode.prototype.orderNodeView = function(recurse){
     if (typeof recurse === 'undefined') var recurse = false;
 
     TB_orderNetworkUpBatchFromList( node.subNodes(this.path) );
@@ -2898,7 +2899,7 @@ $.oGroupNode.prototype.orderNodeView = function(recurse){
  * peg.centerAbove(drawingNode);
  *
  */
-$.oGroupNode.prototype.addNode = function( type, name, nodePosition ){
+exports.oGroupNode.prototype.addNode = function( type, name, nodePosition ){
   // Defaults for optional parameters
   if (typeof nodePosition === 'undefined') var nodePosition = new this.$.oPoint(0,0,0);
   if (typeof name === 'undefined') var name = type[0]+type.slice(1).toLowerCase();
@@ -2935,7 +2936,7 @@ $.oGroupNode.prototype.addNode = function( type, name, nodePosition ){
  * @return {$.oNode}     The created node, or bool as false.
  */
 
-$.oGroupNode.prototype.addDrawingNode = function( name, nodePosition, oElementObject, drawingColumn){
+exports.oGroupNode.prototype.addDrawingNode = function( name, nodePosition, oElementObject, drawingColumn){
   // add drawing column and element if not passed as parameters
   this.$.beginUndo("oH_addDrawingNode_"+name);
 
@@ -2981,7 +2982,7 @@ $.oGroupNode.prototype.addDrawingNode = function( name, nodePosition, oElementOb
 
  * @return {$.oGroupNode}   The created node, or bool as false.
  */
-$.oGroupNode.prototype.addGroup = function( name, addComposite, addPeg, includeNodes, nodePosition ){
+exports.oGroupNode.prototype.addGroup = function( name, addComposite, addPeg, includeNodes, nodePosition ){
     // Defaults for optional parameters
     if (typeof addPeg === 'undefined') var addPeg = false;
     if (typeof addComposite === 'undefined') var addComposite = false;
@@ -3071,7 +3072,7 @@ $.oGroupNode.prototype.addGroup = function( name, addComposite, addPeg, includeN
  *
  * @return {$.oNode[]}         The resulting pasted nodes.
  */
-$.oGroupNode.prototype.importTemplate = function( tplPath, destinationNodes, extendScene, nodePosition, pasteOptions ){
+exports.oGroupNode.prototype.importTemplate = function( tplPath, destinationNodes, extendScene, nodePosition, pasteOptions ){
   if (typeof nodePosition === 'undefined') var nodePosition = new oPoint(0,0,0);
   if (typeof destinationNodes === 'undefined' || destinationNodes.length == 0) var destinationNodes = false;
   if (typeof extendScene === 'undefined') var extendScene = true;
@@ -3151,7 +3152,7 @@ $.oGroupNode.prototype.importTemplate = function( tplPath, destinationNodes, ext
  *
  * @return {$.oBackdrop}       The created backdrop.
  */
-$.oGroupNode.prototype.addBackdrop = function(title, body, color, x, y, width, height ){
+exports.oGroupNode.prototype.addBackdrop = function(title, body, color, x, y, width, height ){
   if (typeof color === 'undefined') var color = new this.$.oColorValue("#323232ff");
   if (typeof body === 'undefined') var body = "";
 
@@ -3232,7 +3233,7 @@ $.oGroupNode.prototype.addBackdrop = function(title, body, color, x, y, width, h
  *  }
  * }
  */
-$.oGroupNode.prototype.addBackdropToNodes = function( nodes, title, body, color, x, y, width, height ){
+exports.oGroupNode.prototype.addBackdropToNodes = function( nodes, title, body, color, x, y, width, height ){
   if (typeof color === 'undefined') var color = new this.$.oColorValue("#323232ff");
   if (typeof body === 'undefined') var body = "";
   if (typeof x === 'undefined') var x = 0;
@@ -3290,7 +3291,7 @@ $.oGroupNode.prototype.addBackdropToNodes = function( nodes, title, body, color,
  *   $.endUndo();
  * }
  */
-$.oGroupNode.prototype.importPSD = function( path, separateLayers, addPeg, addComposite, alignment, nodePosition){
+exports.oGroupNode.prototype.importPSD = function( path, separateLayers, addPeg, addComposite, alignment, nodePosition){
   if (typeof alignment === 'undefined') var alignment = "ASIS" // create an enum for alignments?
   if (typeof addComposite === 'undefined') var addComposite = true;
   if (typeof addPeg === 'undefined') var addPeg = true;
@@ -3414,7 +3415,7 @@ $.oGroupNode.prototype.importPSD = function( path, separateLayers, addPeg, addCo
  *
  * @return  {$.oNode[]}    The nodes that have been updated/created
  */
-$.oGroupNode.prototype.updatePSD = function( path, separateLayers ){
+exports.oGroupNode.prototype.updatePSD = function( path, separateLayers ){
   if (typeof separateLayers === 'undefined') var separateLayers = true;
 
   var _psdFile = (path instanceof this.$.oFile)?path:new this.$.oFile(path);
@@ -3559,7 +3560,7 @@ $.oGroupNode.prototype.updatePSD = function( path, separateLayers ){
  *
  * @return  {$.oNode}    The node for the imported image
  */
-$.oGroupNode.prototype.importImage = function( path, alignment, nodePosition, convertToTvg, resized_axis){
+exports.oGroupNode.prototype.importImage = function( path, alignment, nodePosition, convertToTvg, resized_axis){
 
   if (typeof alignment === 'undefined') var alignment = "ASIS"; // create an enum for alignments?
   if (typeof nodePosition === 'undefined') var nodePosition = new this.$.oPoint(0,0,0);
@@ -3610,7 +3611,7 @@ $.oGroupNode.prototype.importImage = function( path, alignment, nodePosition, co
  * @param {string} [alignment="ASIS"]            the alignment mode for the imported image
  * @param {$.oPoint} [nodePosition={0,0,0}]      the position for the created node.
  */
-$.oGroupNode.prototype.importImageAsTVG = function(path, alignment, nodePosition){
+exports.oGroupNode.prototype.importImageAsTVG = function(path, alignment, nodePosition){
   if (!(path instanceof this.$.oFile)) path = new this.$.oFile(path);
 
   var _imageNode = this.importImage(path, alignment, nodePosition, true);
@@ -3631,7 +3632,7 @@ $.oGroupNode.prototype.importImageAsTVG = function(path, alignment, nodePosition
  *
  * @returns {$.oDrawingNode} the created node
  */
-$.oGroupNode.prototype.importImageSequence = function(imagePaths, exposureLength, convertToTvg, alignment, nodePosition, extendScene, resized_axis) {
+exports.oGroupNode.prototype.importImageSequence = function(imagePaths, exposureLength, convertToTvg, alignment, nodePosition, extendScene, resized_axis) {
   if (typeof exposureLength === 'undefined') var exposureLength = 1;
   if (typeof alignment === 'undefined') var alignment = "ASIS"; // create an enum for alignments?
   if (typeof nodePosition === 'undefined') var nodePosition = new this.$.oPoint(0,0,0);
@@ -3709,7 +3710,7 @@ $.oGroupNode.prototype.importImageSequence = function(imagePaths, exposureLength
  *
  * @return {$.oNode}        The imported Quicktime Node.
  */
-$.oGroupNode.prototype.importQT = function( path, importSound, extendScene, alignment, nodePosition, convertToTvg){
+exports.oGroupNode.prototype.importQT = function( path, importSound, extendScene, alignment, nodePosition, convertToTvg){
   if (typeof alignment === 'undefined') var alignment = "ASIS";
   if (typeof extendScene === 'undefined') var extendScene = true;
   if (typeof importSound === 'undefined') var importSound = true;

--- a/openHarmony/openHarmony_node.js
+++ b/openHarmony/openHarmony_node.js
@@ -372,7 +372,7 @@ Object.defineProperty(exports.oNode.prototype, 'name', {
 Object.defineProperty(exports.oNode.prototype, 'nodeColor', {
   get : function(){
     var _color = node.getColor(this.path);
-    return new $.oColorValue({r:_color.r, g:_color.g, b:_color.b, a:_color.a});
+    return new this.$.oColorValue({r:_color.r, g:_color.g, b:_color.b, a:_color.a});
   },
   set : function(color){
     var _rgbacolor = new ColorRGBA(color.r, color.g, color.b, color.a);
@@ -1150,7 +1150,7 @@ exports.oNode.prototype.findFirstOutNodeOfType = function(type, lookInsideGroups
  */
 exports.oNode.prototype.findFirstInLinkOfType = function(type){
   var _inNode = this.findFirstInNodeMatching(function(x){return x.type == type})
-  if (_inNode) return new $.oLinkPath(_inNode, this);
+  if (_inNode) return new this.$.oLinkPath(_inNode, this);
   return null;
 }
 
@@ -1163,7 +1163,7 @@ exports.oNode.prototype.findFirstInLinkOfType = function(type){
  */
 exports.oNode.prototype.findFirstOutLinkOfType = function(type){
   var _outNode = this.findFirstOutNodeMatching(function(x){return x.type == type})
-  if (_outNode) return new $.oLinkPath(this, _outNode);
+  if (_outNode) return new this.$.oLinkPath(this, _outNode);
   return null;
 }
 
@@ -1470,7 +1470,7 @@ exports.oNode.prototype.orderAboveNodes = function(verticalSpacing, horizontalSp
   if (typeof verticalSpacing === 'undefined') var verticalSpacing = 120;
   if (typeof horizontalSpacing === 'undefined') var horizontalSpacing = 40;
 
-  $.beginUndo()
+  this.$.beginUndo()
 
   var startNode = this;
   var nodeHeights = {}
@@ -1595,7 +1595,7 @@ exports.oNode.prototype.orderAboveNodes = function(verticalSpacing, horizontalSp
   }
 
 
-  $.endUndo()
+  this.$.endUndo()
 }
 
  /**
@@ -2154,7 +2154,7 @@ exports.oDrawingNode.prototype.exposeAllDrawings = function(framesPerDrawing){
   var _drawings = this.element.drawings;
   var frameNumber = 1;
   for (var i=0; i < _drawings.length; i++){
-    //log("showing drawing "+_drawings[i].name+" at frame "+i)
+    //this.$.log("showing drawing "+_drawings[i].name+" at frame "+i)
     this.showDrawingAtFrame(_drawings[i], frameNumber);
     frameNumber+=framesPerDrawing;
   }
@@ -3073,7 +3073,7 @@ exports.oGroupNode.prototype.addGroup = function( name, addComposite, addPeg, in
  * @return {$.oNode[]}         The resulting pasted nodes.
  */
 exports.oGroupNode.prototype.importTemplate = function( tplPath, destinationNodes, extendScene, nodePosition, pasteOptions ){
-  if (typeof nodePosition === 'undefined') var nodePosition = new oPoint(0,0,0);
+  if (typeof nodePosition === 'undefined') var nodePosition = new this.$.oPoint(0,0,0);
   if (typeof destinationNodes === 'undefined' || destinationNodes.length == 0) var destinationNodes = false;
   if (typeof extendScene === 'undefined') var extendScene = true;
 

--- a/openHarmony/openHarmony_node.js
+++ b/openHarmony/openHarmony_node.js
@@ -192,7 +192,7 @@ exports.oNode.prototype.setAttrGetterSetter = function (attr, context, oNodeObje
                 var _value = newValue;
                 // dealing with value being an object with frameNumber for animated values
                 if (attr.column != null) {
-                    if (!(newValue instanceof oFrame)) {
+                    if (!(newValue instanceof this.$.oFrame)) {
                         // fallback to set frame 1
                         newValue = {value:newValue, frameNumber:1};
                     }
@@ -1272,7 +1272,7 @@ exports.oNode.prototype.insertInNode = function( inPort, oNodeObject, inPortTarg
  */
 exports.oNode.prototype.moveToGroup = function(group){
   var _name = this.name;
-  if (group instanceof oGroupNode) group = group.path;
+  if (group instanceof this.$.oGroupNode) group = group.path;
 
   if (this.group != group){
     this.$.beginUndo("oH_moveNodeToGroup_"+_name)

--- a/openHarmony/openHarmony_nodeLink.js
+++ b/openHarmony/openHarmony_nodeLink.js
@@ -91,7 +91,7 @@
  *  var peg5     = $.scene.getNodeByPath( "Top/Group/Peg5" );
  *  var newLink  = peg1.addOutLink( peg5 );
  */
-$.oNodeLink = function( outNode, outPort, inNode, inPort, outlink ){
+exports.oNodeLink = function( outNode, outPort, inNode, inPort, outlink ){
 
     //Public properties.
     this.autoDisconnect = true;
@@ -146,7 +146,7 @@ $.oNodeLink = function( outNode, outPort, inNode, inPort, outlink ){
  *                              0 );      //In Port
  *  link.exists == false;   //FALSE, This link doesnt exist in this context, because the node doesnt exist.
  */
-Object.defineProperty($.oNodeLink.prototype, 'exists', {
+Object.defineProperty(exports.oNodeLink.prototype, 'exists', {
     get : function(){
       if( !this._validated ){
         this.validate();
@@ -161,7 +161,7 @@ Object.defineProperty($.oNodeLink.prototype, 'exists', {
  * @name $.oNodeLink#outNode
  * @type {$.oNode}
  */
-Object.defineProperty($.oNodeLink.prototype, 'outNode', {
+Object.defineProperty(exports.oNodeLink.prototype, 'outNode', {
     get : function(){
       return this._outNode;
 
@@ -184,7 +184,7 @@ Object.defineProperty($.oNodeLink.prototype, 'outNode', {
  * @name $.oNodeLink#inNode
  * @type {$.oNode}
  */
-Object.defineProperty($.oNodeLink.prototype, 'inNode', {
+Object.defineProperty(exports.oNodeLink.prototype, 'inNode', {
     get : function(){
       return this._inNode;
     },
@@ -208,7 +208,7 @@ Object.defineProperty($.oNodeLink.prototype, 'inNode', {
  * @name $.oNodeLink#outPort
  * @type {int}
  */
-Object.defineProperty($.oNodeLink.prototype, 'outPort', {
+Object.defineProperty(exports.oNodeLink.prototype, 'outPort', {
     get : function(){
       return this._outPort;
 
@@ -232,7 +232,7 @@ Object.defineProperty($.oNodeLink.prototype, 'outPort', {
  * @name $.oNodeLink#outLink
  * @type {int}
  */
-Object.defineProperty($.oNodeLink.prototype, 'outLink', {
+Object.defineProperty(exports.oNodeLink.prototype, 'outLink', {
     get : function(){
       return this._outLink;
     }
@@ -244,7 +244,7 @@ Object.defineProperty($.oNodeLink.prototype, 'outLink', {
  * @name $.oNodeLink#inPort
  * @type {oNode[]}
  */
-Object.defineProperty($.oNodeLink.prototype, 'inPort', {
+Object.defineProperty(exports.oNodeLink.prototype, 'inPort', {
     get : function(){
       return this._inPort;
     },
@@ -267,7 +267,7 @@ Object.defineProperty($.oNodeLink.prototype, 'inPort', {
  * @private
  * @type {bool}
  */
-Object.defineProperty($.oNodeLink.prototype, 'stopUpdates', {
+Object.defineProperty(exports.oNodeLink.prototype, 'stopUpdates', {
     get : function(){
       return this._stopUpdates;
     },
@@ -290,7 +290,7 @@ Object.defineProperty($.oNodeLink.prototype, 'stopUpdates', {
  * @private
  * @return {object}                   Object in form { "node":oNode, "port":int, "link": int }
  */
-$.oNodeLink.prototype.findInputPath = function( onode, port, path ) {
+exports.oNodeLink.prototype.findInputPath = function( onode, port, path ) {
   var srcNodeInfo = node.srcNodeInfo( onode.path, port );
   if( !srcNodeInfo ){
     return path;
@@ -341,7 +341,7 @@ $.oNodeLink.prototype.findInputPath = function( onode, port, path ) {
  *  var outLinks  = peg1.outLinks;
  *  outLinks[0].linkIn( peg2, 0 ); //Links the input of peg2, port 0 -- to this link, connecting its outNode [peg1] and outPort [0] and outLink [arbitrary].
  */
-$.oNodeLink.prototype.linkIn = function( onode, port ) {
+exports.oNodeLink.prototype.linkIn = function( onode, port ) {
   this._validated = false;
   var stopUpdates_val = this.stopUpdates;
   this.stopUpdates = true;
@@ -365,7 +365,7 @@ $.oNodeLink.prototype.linkIn = function( onode, port ) {
  *  var inLinks  = peg1.inLinks;
  *  inLinks[0].linkOut( peg2, 0 ); //Links the output of peg2, port 0 -- to this link, connecting its inNode [peg1] and inPort [0].
  */
-$.oNodeLink.prototype.linkOut = function( onode, port ) {
+exports.oNodeLink.prototype.linkOut = function( onode, port ) {
   this._validated = false;
 
   var stopUpdates_val = this.stopUpdates;
@@ -398,7 +398,7 @@ $.oNodeLink.prototype.linkOut = function( onode, port ) {
  *  var peg4     = $.scene.getNodeByPath( "Top/Peg4" );
  *  link.insertNode(  peg4, 0, 0 ); //Peg to insert, in port, out port.
  */
-$.oNodeLink.prototype.insertNode = function( nodeToInsert, inPort, outPort ) {
+exports.oNodeLink.prototype.insertNode = function( nodeToInsert, inPort, outPort ) {
   this.stopUpdates = true;
 
   var inNode = this.inNode;
@@ -430,7 +430,7 @@ $.oNodeLink.prototype.insertNode = function( nodeToInsert, inPort, outPort ) {
  *  //The node link doesn't exist yet, but lets apply it.
  *  link.apply();
  */
-$.oNodeLink.prototype.apply = function( force ) {
+exports.oNodeLink.prototype.apply = function( force ) {
   this._stopUpdates = false;
   this._validated = false; // ? Shouldn't we use this to bypass application if it's already been validated?
 
@@ -684,7 +684,7 @@ $.oNodeLink.prototype.apply = function( force ) {
  *                                                       "createPort" : bool
  *                                                      }
  */
-$.oNodeLink.prototype.findInwardPath = function( createPort ){
+exports.oNodeLink.prototype.findInwardPath = function( createPort ){
   var from_node = this._outNode;
   var from_port = this._outPort;
   var targ_node = this._inNode;
@@ -792,7 +792,7 @@ $.oNodeLink.prototype.findInwardPath = function( createPort ){
  *                                                       "createPort" : bool
  *                                                      }
  */
-$.oNodeLink.prototype.findOutwardPath = function(){
+exports.oNodeLink.prototype.findOutwardPath = function(){
   var from_node = this._outNode;
   var port = this._outPort;
   var targ = this._inNode;
@@ -844,7 +844,7 @@ $.oNodeLink.prototype.findOutwardPath = function(){
  * @private
  * @return {bool}      Whether the connection is a valid connection that exists currently in the node system.
  */
-$.oNodeLink.prototype.validate = function ( ) {
+exports.oNodeLink.prototype.validate = function ( ) {
     //Initialize the connection and get the information.
     //First check to see if the path is valid.
     this._exists    = false;
@@ -982,7 +982,7 @@ $.oNodeLink.prototype.validate = function ( ) {
  * @param   {bool}                  outportProvided          Was an outport provided.
  * @return {bool}      Whether the connection is a valid connection that exists currently in the node system.
  */
-$.oNodeLink.prototype.validateUpwards = function( inport, outportProvided ) {
+exports.oNodeLink.prototype.validateUpwards = function( inport, outportProvided ) {
   //IN THE EVENT OUTNODE WASNT PROVIDED.
   this.path = this.findInputPath( this._inNode, inport, [] );
   if( !this.path || this.path.length == 0 ){
@@ -1023,7 +1023,7 @@ $.oNodeLink.prototype.validateUpwards = function( inport, outportProvided ) {
 /**
  * Converts the node link to a string.
  */
-$.oNodeLink.prototype.toString = function( ) {
+exports.oNodeLink.prototype.toString = function( ) {
   return '{"inNode":"'+this.inNode+'", "inPort":"'+this.inPort+'", "outNode":"'+this.outNode+'", "outPort":"'+this.outPort+'", "outLink":"'+this.outLink+'" }';
 }
 
@@ -1081,7 +1081,7 @@ $.oNodeLink.prototype.toString = function( ) {
  *
  * myLink.connect()     // this will connect the nodes once more, with different ports. A new connection is created.
  */
-$.oLink = function(outNode, inNode, outPortNum, inPortNum, outLinkNum, isValid){
+exports.oLink = function(outNode, inNode, outPortNum, inPortNum, outLinkNum, isValid){
   this._outNode = outNode;
   this._inNode = inNode;
   this._outPort = (typeof outPortNum !== 'undefined')? outPortNum:undefined;
@@ -1095,7 +1095,8 @@ $.oLink = function(outNode, inNode, outPortNum, inPortNum, outLinkNum, isValid){
  * The node that the link is coming out of. Changing this value doesn't reconnect the link, just changes the connection described by the link object.
  * @name $.oLink#outNode
  * @type {$.oNode}
- */Object.defineProperty($.oLink.prototype, 'outNode', {
+ */
+Object.defineProperty(exports.oLink.prototype, 'outNode', {
   get : function(){
     return this._outNode;
   },
@@ -1112,7 +1113,7 @@ $.oLink = function(outNode, inNode, outPortNum, inPortNum, outLinkNum, isValid){
  * @name $.oLink#inNode
  * @type {$.oNode}
  */
-Object.defineProperty($.oLink.prototype, 'inNode', {
+Object.defineProperty(exports.oLink.prototype, 'inNode', {
   get : function(){
     return this._inNode;
   },
@@ -1130,7 +1131,7 @@ Object.defineProperty($.oLink.prototype, 'inNode', {
  * @name $.oLink#inPort
  * @type {int}
  */
-Object.defineProperty($.oLink.prototype, 'inPort', {
+Object.defineProperty(exports.oLink.prototype, 'inPort', {
   get : function(){
     if (this.linked) return this._inPort;  // cached value was correct
 
@@ -1154,7 +1155,7 @@ Object.defineProperty($.oLink.prototype, 'inPort', {
  * @name $.oLink#outPort
  * @type {int}
  */
-Object.defineProperty($.oLink.prototype, 'outPort', {
+Object.defineProperty(exports.oLink.prototype, 'outPort', {
   get : function(){
     if (this.linked) return this._outPort;  // cached value was correct
 
@@ -1179,7 +1180,7 @@ Object.defineProperty($.oLink.prototype, 'outPort', {
  * @readonly
  * @type {int}
  */
-Object.defineProperty($.oLink.prototype, 'outLink', {
+Object.defineProperty(exports.oLink.prototype, 'outLink', {
   get : function(){
     if (this.linked) return this._outLink;
 
@@ -1197,7 +1198,7 @@ Object.defineProperty($.oLink.prototype, 'outLink', {
  * @name $.oLink#linked
  * @type {bool}
  */
-Object.defineProperty($.oLink.prototype, 'linked', {
+Object.defineProperty(exports.oLink.prototype, 'linked', {
   get : function(){
     if (this._linked) return this._linked;
 
@@ -1246,7 +1247,7 @@ Object.defineProperty($.oLink.prototype, 'linked', {
  * @readonly
  * @type {bool}
  */
-Object.defineProperty($.oLink.prototype, 'isMultiLevel', {
+Object.defineProperty(exports.oLink.prototype, 'isMultiLevel', {
   get : function(){
     //this.$.debug("isMultiLevel? "+this.outNode +" "+this.inNode, this.$.DEBUG_LEVEL.LOG);
     if (!this.outNode || !this.outNode.group || !this.inNode || !this.inNode.group) return false;
@@ -1261,7 +1262,7 @@ Object.defineProperty($.oLink.prototype, 'isMultiLevel', {
  * @readonly
  * @type {bool}
  */
-Object.defineProperty($.oLink.prototype, 'waypoints', {
+Object.defineProperty(exports.oLink.prototype, 'waypoints', {
   get : function(){
     if (!this.linked) return []
     var _waypoints = waypoint.getAllWaypointsAbove (this.inNode, this.inPort)
@@ -1274,7 +1275,7 @@ Object.defineProperty($.oLink.prototype, 'waypoints', {
  * Get a link that can be connected by working out ports that can be used. If a link already exists, it will be returned.
  * @return {$.oLink} A separate $.oLink object that can be connected. Null if none could be constructed.
  */
-$.oLink.prototype.getValidLink = function(createOutPorts, createInPorts){
+exports.oLink.prototype.getValidLink = function(createOutPorts, createInPorts){
   if (typeof createOutPorts === 'undefined') var createOutPorts = false;
   if (typeof createInPorts === 'undefined') var createInPorts = true;
   var start = this.outNode;
@@ -1326,7 +1327,7 @@ $.oLink.prototype.getValidLink = function(createOutPorts, createInPorts){
  * Attemps to connect a link. Will guess the ports if not provided.
  * @return {bool}
  */
-$.oLink.prototype.connect = function(){
+exports.oLink.prototype.connect = function(){
   if (this._linked){
     return true;
   }
@@ -1369,7 +1370,7 @@ $.oLink.prototype.connect = function(){
  * Disconnects a link.
  * @return {bool} Whether disconnecting was successful;
  */
-$.oLink.prototype.disconnect = function(){
+exports.oLink.prototype.disconnect = function(){
   if (!this._linked) return true;
 
   if (!this.findPorts()) return false;
@@ -1386,7 +1387,7 @@ $.oLink.prototype.disconnect = function(){
  * @private
  * @return {bool} Whether finding ports was successful.
  */
-$.oLink.prototype.findPorts = function(){
+exports.oLink.prototype.findPorts = function(){
   // Unless some ports are specified, this will always find the first link and stop there. Provide more info in case of multiple links
 
   if (!this.outNode|| !this.inNode) {
@@ -1466,7 +1467,7 @@ $.oLink.prototype.findPorts = function(){
  * var link = new $.oLink(node1, node2)
  * link.insertNode(node3) // insert the Transparency node between the Drawing and Composite
  */
-$.oLink.prototype.insertNode = function(oNode, nodeInPort, nodeOutPort, nodeOutLink){
+exports.oLink.prototype.insertNode = function(oNode, nodeInPort, nodeOutPort, nodeOutLink){
   if (!this.linked) return    // can't insert a node if the link isn't connected
 
   this.$.beginUndo("oh_insertNode")
@@ -1499,7 +1500,7 @@ $.oLink.prototype.insertNode = function(oNode, nodeInPort, nodeOutPort, nodeOutL
  * Converts the node link to a string.
  * @private
  */
-$.oLink.prototype.toString = function( ) {
+exports.oLink.prototype.toString = function( ) {
   return ('link: {"'+this._outNode+'" ['+this._outPort+', '+this._outLink+'] -> "'+this._inNode+'" ['+this._inPort+']} linked:'+this._linked);
   // return '{outNode:'+this.outNode+' inNode:'+this.inNode+' }';
 }
@@ -1531,7 +1532,7 @@ $.oLink.prototype.toString = function( ) {
  * @param   {oScene}         [outLinkNum]                    The link index coming out of the out-port of the startNode.
  * @see NodeType
  */
-$.oLinkPath = function( startNode, endNode, outPort, inPort, outLink){
+exports.oLinkPath = function( startNode, endNode, outPort, inPort, outLink){
   this.startNode = startNode;
   this.endNode = endNode;
   this.outPort = (typeof outPort !== 'undefined')? outPort:undefined;
@@ -1546,7 +1547,7 @@ $.oLinkPath = function( startNode, endNode, outPort, inPort, outLink){
  * @readonly
  * @type {bool}
  */
-Object.defineProperty($.oLinkPath.prototype, 'isMultiLevel', {
+Object.defineProperty(exports.oLinkPath.prototype, 'isMultiLevel', {
   get : function(){
     //this.$.log(this.startNode+" "+this.endNode)
     return this.startNode.group.path != this.endNode.group.path;
@@ -1560,7 +1561,7 @@ Object.defineProperty($.oLinkPath.prototype, 'isMultiLevel', {
  * @readonly
  * @type {$.oGroupNode}
  */
-Object.defineProperty($.oLinkPath.prototype, 'lowestCommonGroup', {
+Object.defineProperty(exports.oLinkPath.prototype, 'lowestCommonGroup', {
   get : function(){
     var startPath = this.startNode.group.path.split("/");
     var endPath = this.endNode.group.path.split("/");
@@ -1581,7 +1582,7 @@ Object.defineProperty($.oLinkPath.prototype, 'lowestCommonGroup', {
  *
  * @return {$.oLink[]} The list of successive $.oLink objects describing the path. Returns null if no such path could be found.
  */
-$.oLinkPath.prototype.findExistingPath = function(){
+exports.oLinkPath.prototype.findExistingPath = function(){
   // looking for the startNode from the endNode going up since the hierarchy is usually simpler this direction
   // if inPort is provided, we assume it's correct or a search filter, otherwise look up all inLinks
   var _searchPorts = (this.inPort !== undefined)?[this.inPort]:Array.apply(null, new Array(this.endNode.inPorts)).map(function (x, i) {return i;});
@@ -1631,7 +1632,7 @@ $.oLinkPath.prototype.findExistingPath = function(){
  *
  * @return {$.oLink} the valid $.oLink object.  Returns null if no such link could be created (for example if the node's in-port is already linked)
  */
-$.oLinkPath.prototype.getValidLink = function(start, end, outPort, inPort){
+exports.oLinkPath.prototype.getValidLink = function(start, end, outPort, inPort){
   var _link = new $.oLink(start, end, outPort, inPort)
   return _link.getValidLink();
 }
@@ -1642,7 +1643,7 @@ $.oLinkPath.prototype.getValidLink = function(start, end, outPort, inPort){
  *
  * @return {$.oLink[]}     The list of links needed for the path. Some can already be connected.
  */
-$.oLinkPath.prototype.findNewPath = function(){
+exports.oLinkPath.prototype.findNewPath = function(){
   // look for the lowest common group we will have to reach first
   subLinks = [];
   var commonGroup = this.lowestCommonGroup;
@@ -1702,7 +1703,7 @@ $.oLinkPath.prototype.findNewPath = function(){
  * @return {$.oLink[]} return the list of links present in the created path
  */
 
-$.oLinkPath.prototype.connectPath = function(){
+exports.oLinkPath.prototype.connectPath = function(){
   var newPath = this.findNewPath();
 
   for (var i in newPath){

--- a/openHarmony/openHarmony_nodeLink.js
+++ b/openHarmony/openHarmony_nodeLink.js
@@ -1284,7 +1284,7 @@ exports.oLink.prototype.getValidLink = function(createOutPorts, createInPorts){
   var inPort = this._inPort;
 
   if (!start || !end) {
-    $.debug("A valid link can't be found: node missing in link "+this.toString(), this.$.DEBUG_LEVEL.ERROR)
+    this.$.debug("A valid link can't be found: node missing in link "+this.toString(), this.$.DEBUG_LEVEL.ERROR)
     return null;
   }
 
@@ -1633,7 +1633,7 @@ exports.oLinkPath.prototype.findExistingPath = function(){
  * @return {$.oLink} the valid $.oLink object.  Returns null if no such link could be created (for example if the node's in-port is already linked)
  */
 exports.oLinkPath.prototype.getValidLink = function(start, end, outPort, inPort){
-  var _link = new $.oLink(start, end, outPort, inPort)
+  var _link = new this.$.oLink(start, end, outPort, inPort)
   return _link.getValidLink();
 }
 

--- a/openHarmony/openHarmony_palette.js
+++ b/openHarmony/openHarmony_palette.js
@@ -62,7 +62,7 @@
  * @property   {palette}                 paletteObject          The Harmony palette object.
  * @property   {oSceneObject}            scene                  The DOM Scene object.
  */
-$.oPalette = function (paletteObject, paletteListObject) {
+exports.oPalette = function (paletteObject, paletteListObject) {
   this._type = "palette";
 
   this.paletteObject = paletteObject;
@@ -72,7 +72,7 @@ $.oPalette = function (paletteObject, paletteListObject) {
 
 
 // Class properties
-$.oPalette.location = {
+exports.oPalette.location = {
   "environment": PaletteObjectManager.Constants.Location.ENVIRONMENT,
   "job": PaletteObjectManager.Constants.Location.JOB,
   "scene": PaletteObjectManager.Constants.Location.SCENE,
@@ -87,7 +87,7 @@ $.oPalette.location = {
  * @name $.oPalette#id
  * @type {string}
  */
-Object.defineProperty($.oPalette.prototype, 'id', {
+Object.defineProperty(exports.oPalette.prototype, 'id', {
   get: function () {
     return this.paletteObject.id;
   }
@@ -99,7 +99,7 @@ Object.defineProperty($.oPalette.prototype, 'id', {
  * @name $.oPalette#name
  * @type {string}
  */
-Object.defineProperty($.oPalette.prototype, 'name', {
+Object.defineProperty(exports.oPalette.prototype, 'name', {
   get: function () {
     return this.paletteObject.getName();
   },
@@ -130,7 +130,7 @@ Object.defineProperty($.oPalette.prototype, 'name', {
  * @name $.oPalette#index
  * @type {int}
  */
-Object.defineProperty($.oPalette.prototype, 'index', {
+Object.defineProperty(exports.oPalette.prototype, 'index', {
   get: function () {
     var _list = this._paletteList;
     var _n = _list.numPalettes;
@@ -155,7 +155,7 @@ Object.defineProperty($.oPalette.prototype, 'index', {
  * @type {$.oElement}
  * @readonly
  */
-Object.defineProperty($.oPalette.prototype, 'element', {
+Object.defineProperty(exports.oPalette.prototype, 'element', {
   get: function () {
     var _storage = this.paletteStorage;
     var _paletteObject = this._paletteObject;
@@ -171,7 +171,7 @@ Object.defineProperty($.oPalette.prototype, 'element', {
  * @type {$.oFile}
  * @readonly
  */
-Object.defineProperty($.oPalette.prototype, 'path', {
+Object.defineProperty(exports.oPalette.prototype, 'path', {
   get: function () {
     var _path = this.paletteObject.getPath();
     return new this.$.oFile(_path + "/" + this.name + ".plt");
@@ -184,7 +184,7 @@ Object.defineProperty($.oPalette.prototype, 'path', {
  * @name $.oPalette#paletteStorage
  * @type {$.oFile}
  */
-Object.defineProperty($.oPalette.prototype, 'paletteStorage', {
+Object.defineProperty(exports.oPalette.prototype, 'paletteStorage', {
   get: function () {
     var _location = this.$.oPalette.location;
     var _storage = {
@@ -213,7 +213,7 @@ Object.defineProperty($.oPalette.prototype, 'paletteStorage', {
  * @name $.oPalette#selected
  * @type {bool}
  */
-Object.defineProperty($.oPalette.prototype, 'selected', {
+Object.defineProperty(exports.oPalette.prototype, 'selected', {
   get: function () {
     var _currentId = PaletteManager.getCurrentPaletteId()
     return this.id == _currentId;
@@ -234,7 +234,7 @@ Object.defineProperty($.oPalette.prototype, 'selected', {
  * @name $.oPalette#colors
  * @type {oColor[]}
  */
-Object.defineProperty($.oPalette.prototype, 'colors', {
+Object.defineProperty(exports.oPalette.prototype, 'colors', {
   get: function () {
     var _palette = this.paletteObject
     var _colors = []
@@ -251,7 +251,7 @@ Object.defineProperty($.oPalette.prototype, 'colors', {
  * @name $.oPalette#currentColor
  * @type {oColor}
  */
-Object.defineProperty($.oPalette.prototype, 'currentColor', {
+Object.defineProperty(exports.oPalette.prototype, 'currentColor', {
   get: function () {
     var id = PaletteManager.getCurrentColorId()
     return this.getColorById(id)
@@ -271,7 +271,7 @@ Object.defineProperty($.oPalette.prototype, 'currentColor', {
  * @param {string}        name        the display name for the newly created color
  * @param {$.oColorValue} colorValue  a $.oColorValue object describing the color
  */
-$.oPalette.prototype.addColor = function (name, colorValue) {
+exports.oPalette.prototype.addColor = function (name, colorValue) {
   var colorData = {r : colorValue.r, g: colorValue.g, b: colorValue.b, a : colorValue.a };
   this.paletteObject.createNewSolidColor(name, colorData);
 
@@ -284,7 +284,7 @@ $.oPalette.prototype.addColor = function (name, colorValue) {
  * @param {string} texturePath
  * @param {bool} tiled  Wether the texture will be tiled or not
  */
-$.oPalette.prototype.addTexture = function (name, texturePath, tiled) {
+exports.oPalette.prototype.addTexture = function (name, texturePath, tiled) {
   if (typeof texturePath === this.$.oFile) texturePath = texturePath.path;
   this.paletteObject.createNewTexture(name, texturePath, tiled);
 
@@ -298,7 +298,7 @@ $.oPalette.prototype.addTexture = function (name, texturePath, tiled) {
  * @param {object} colorValues an object with keys between 0 and 1 containing a colorValue for each "tack". ex: {0: new $.oColorValue("000000ff"), 1:new $.oColorValue("ffffffff")}
  * @param {bool} radial
  */
-$.oPalette.prototype.addGradient = function (name, colorValues, radial) {
+exports.oPalette.prototype.addGradient = function (name, colorValues, radial) {
   if (typeof radial === 'undefined') var radial = false;
 
   var types = PaletteObjectManager.Constants.ColorType;
@@ -321,7 +321,7 @@ $.oPalette.prototype.addGradient = function (name, colorValues, radial) {
  *
  * @return: {oColor}     the found oColor object.
  */
-$.oPalette.prototype.getColorById = function (id) {
+exports.oPalette.prototype.getColorById = function (id) {
   var _colors = this.colors;
   for (var i in _colors){
     if (_colors[i].id == id) return _colors[i];
@@ -336,7 +336,7 @@ $.oPalette.prototype.getColorById = function (id) {
  *
  * @return: {oColor}     the found oColor object.
  */
- $.oPalette.prototype.getColorByName = function (name) {
+ exports.oPalette.prototype.getColorByName = function (name) {
   var _colors = this.colors;
   var _names = _colors.map(function (x) { return x.name })
   var _colorIndex = _names.indexOf(name)
@@ -351,7 +351,7 @@ $.oPalette.prototype.getColorById = function (id) {
  *
  * @return: {bool}       The success-result of the removal.
  */
-$.oPalette.prototype.remove = function (removeFile) {
+exports.oPalette.prototype.remove = function (removeFile) {
   if (typeof removeFile === 'undefined') var removeFile = false;
 
   var success = false;
@@ -376,6 +376,6 @@ $.oPalette.prototype.remove = function (removeFile) {
 }
 
 
-$.oPalette.prototype.toString = function(){
+exports.oPalette.prototype.toString = function(){
   return this.path.path || this.name;
 }

--- a/openHarmony/openHarmony_path.js
+++ b/openHarmony/openHarmony_path.js
@@ -58,7 +58,7 @@
  * @property {oColumn}                 column                The column this point belongs to
  * @property {oFrame}                  frame                 The frame on which the point is placed.
  */
-$.oPathPoint = function(oColumnObject, oFrameObject){
+exports.oPathPoint = function(oColumnObject, oFrameObject){
   this.column = oColumnObject;
   this.frame = oFrameObject;
 }
@@ -68,7 +68,7 @@ $.oPathPoint = function(oColumnObject, oFrameObject){
  * @name $.oPathPoint#position
  * @type {$.oPoint}
  */
-Object.defineProperty($.oPathPoint.prototype, 'position', {
+Object.defineProperty(exports.oPathPoint.prototype, 'position', {
   get: function(){
     return new this.$.oPoint(this.x, this.y, this.z);
   },
@@ -86,7 +86,7 @@ Object.defineProperty($.oPathPoint.prototype, 'position', {
  * @name $.oPathPoint#pointIndex
  * @type {int}
  */
-Object.defineProperty($.oPathPoint.prototype, 'pointIndex', {
+Object.defineProperty(exports.oPathPoint.prototype, 'pointIndex', {
     get : function(){
          return this.frame.keyframeIndex;
     }
@@ -98,7 +98,7 @@ Object.defineProperty($.oPathPoint.prototype, 'pointIndex', {
  * @name $.oPathPoint#x
  * @type {float}
  */
-Object.defineProperty($.oPathPoint.prototype, 'x', {
+Object.defineProperty(exports.oPathPoint.prototype, 'x', {
     get : function(){
          var _column = this.column.uniqueName;
          var _index = this.pointIndex;
@@ -121,7 +121,7 @@ Object.defineProperty($.oPathPoint.prototype, 'x', {
  * @name $.oPathPoint#y
  * @type {float}
  */
-Object.defineProperty($.oPathPoint.prototype, 'y', {
+Object.defineProperty(exports.oPathPoint.prototype, 'y', {
     get : function(){
          var _column = this.column.uniqueName;
          var _index = this.pointIndex;
@@ -144,7 +144,7 @@ Object.defineProperty($.oPathPoint.prototype, 'y', {
  * @name $.oPathPoint#z
  * @type {float}
  */
-Object.defineProperty($.oPathPoint.prototype, 'z', {
+Object.defineProperty(exports.oPathPoint.prototype, 'z', {
     get : function(){
          var _column = this.column.uniqueName;
          var _index = this.pointIndex;
@@ -167,7 +167,7 @@ Object.defineProperty($.oPathPoint.prototype, 'z', {
  * @name $.oPathPoint#tension
  * @type {float}
  */
-Object.defineProperty($.oPathPoint.prototype, 'tension', {
+Object.defineProperty(exports.oPathPoint.prototype, 'tension', {
     get : function(){
          var _column = this.column.uniqueName;
          var _index = this.pointIndex;
@@ -188,7 +188,7 @@ Object.defineProperty($.oPathPoint.prototype, 'tension', {
  * @name $.oPathPoint#continuity
  * @type {float}
  */
-Object.defineProperty($.oPathPoint.prototype, 'continuity', {
+Object.defineProperty(exports.oPathPoint.prototype, 'continuity', {
     get : function(){
          var _column = this.column.uniqueName;
          var _index = this.pointIndex;
@@ -209,7 +209,7 @@ Object.defineProperty($.oPathPoint.prototype, 'continuity', {
  * @name $.oPathPoint#bias
  * @type {float}
  */
-Object.defineProperty($.oPathPoint.prototype, 'bias', {
+Object.defineProperty(exports.oPathPoint.prototype, 'bias', {
     get : function(){
          var _column = this.column.uniqueName;
          var _index = this.pointIndex;
@@ -231,7 +231,7 @@ Object.defineProperty($.oPathPoint.prototype, 'bias', {
  * @name $.oPathPoint#lock
  * @type {float}
  */
-Object.defineProperty($.oPathPoint.prototype, 'lock', {
+Object.defineProperty(exports.oPathPoint.prototype, 'lock', {
     get : function(){
          var _column = this.column.uniqueName;
          var _index = this.pointIndex;
@@ -252,7 +252,7 @@ Object.defineProperty($.oPathPoint.prototype, 'lock', {
  * @name $.oPathPoint#velocity
  * @type {float}
  */
-Object.defineProperty($.oPathPoint.prototype, 'velocity', {
+Object.defineProperty(exports.oPathPoint.prototype, 'velocity', {
     get : function(){
          var _column = this.column.uniqueName;
          return column.getEntry(this.column.uniqueName, 4, this.frame.frameNumber)
@@ -271,7 +271,7 @@ Object.defineProperty($.oPathPoint.prototype, 'velocity', {
  * Matches this path point to the provided one.
  * @param   {$.oPathPoint}    pseudoPathPoint                The path point object to match this to.
  */
-$.oPathPoint.prototype.set = function( pseudoPathPoint ){
+exports.oPathPoint.prototype.set = function( pseudoPathPoint ){
     // Set a point by providing all values in an object corresponding to a dumb $.oPathPoint object with static values for each property;
     var _point = pseudoPathPoint;
 
@@ -293,6 +293,6 @@ $.oPathPoint.prototype.set = function( pseudoPathPoint ){
  * Converts the pathpoint to a string.
  * @return {string}    The pathpoint represented as a string.
  */
-$.oPathPoint.prototype.toString = function(){
+exports.oPathPoint.prototype.toString = function(){
     return "{x:"+this.x+", y:"+this.y+", z:"+this.z+"}"
 }

--- a/openHarmony/openHarmony_preferencedoc.js
+++ b/openHarmony/openHarmony_preferencedoc.js
@@ -88,14 +88,14 @@
  * 
  * //the details objects of the preferences object allows access to more information about each preference
  * var details = prefs.details
- * log(details.USE_OVERLAY_UNDERLAY_ART.category+" "+details.USE_OVERLAY_UNDERLAY_ART.id+" "+details.USE_OVERLAY_UNDERLAY_ART.type);
+ * $.log(details.USE_OVERLAY_UNDERLAY_ART.category+" "+details.USE_OVERLAY_UNDERLAY_ART.id+" "+details.USE_OVERLAY_UNDERLAY_ART.type);
  * 
  * for (var i in details){
- *   log(i+" "+JSON.stringify(details[i]))       // each object inside detail is a complete oPreference instance
+ *   $.log(i+" "+JSON.stringify(details[i]))       // each object inside detail is a complete oPreference instance
  * }
  * 
  * // the preference object also holds a categories array with the list of all categories
- * log (prefs.categories)
+ * $.log (prefs.categories)
  */
 
 /**

--- a/openHarmony/openHarmony_preferences.js
+++ b/openHarmony/openHarmony_preferences.js
@@ -486,7 +486,7 @@ Object.defineProperty (exports.oPreference.prototype, 'value', {
  */
 exports.oPreference.createPreference = function(category, keyword, type, value, description, descriptionText, prefObject){
   if (!prefObject.details.hasOwnProperty(keyword)){
-    var pref = new this.$.oPreference(category, keyword, type, value, description, descriptionText);
+    var pref = new exports.oPreference(category, keyword, type, value, description, descriptionText);
     Object.defineProperty(prefObject, keyword,{
       enumerable: true,
       get : function(){

--- a/openHarmony/openHarmony_preferences.js
+++ b/openHarmony/openHarmony_preferences.js
@@ -188,7 +188,7 @@ exports.oPreferences.prototype.refresh = function(){
       switch( type ){
       case 'color':
         var tempVal = preferences.getColor( id, new ColorRGBA () );
-        value = new $.oColorValue( tempVal.r, tempVal.g, tempVal.b, tempVal.a );
+        value = new this.$.oColorValue( tempVal.r, tempVal.g, tempVal.b, tempVal.a );
         break;
       case 'int':
         value = preferences.getInt( id, 0 );
@@ -401,14 +401,14 @@ exports.oPreferences.prototype.get = function( name ){
  *
  * //the details objects of the preferences object allows access to more information about each preference
  * var details = prefs.details
- * log(details.USE_OVERLAY_UNDERLAY_ART.category+" "+details.USE_OVERLAY_UNDERLAY_ART.id+" "+details.USE_OVERLAY_UNDERLAY_ART.type);
+ * $.log(details.USE_OVERLAY_UNDERLAY_ART.category+" "+details.USE_OVERLAY_UNDERLAY_ART.id+" "+details.USE_OVERLAY_UNDERLAY_ART.type);
  *
  * for (var i in details){
- *   log(i+" "+JSON.stringify(details[i]))       // each object inside detail is a complete oPreference instance
+ *   $.log(i+" "+JSON.stringify(details[i]))       // each object inside detail is a complete oPreference instance
  * }
  *
  * // the preference object also holds a categories array with the list of all categories
- * log (prefs.categories)
+ * $.log (prefs.categories)
  */
 exports.oPreference = function(category, keyword, type, value, description, descriptionText){
   this.category = category;
@@ -463,7 +463,7 @@ Object.defineProperty (exports.oPreference.prototype, 'value', {
         preferences.setDouble(this.keyword, newValue);
         break;
       case "color":
-        if (typeof newValue == String) newValue = (new oColorValue()).fromColorString(newValue);
+        if (typeof newValue == String) newValue = (new this.$.oColorValue()).fromColorString(newValue);
         preferences.setColor(this.keyword, new ColorRGBA(newValue.r, newValue.g, newValue.b, newValue.a));
         break;
       default:
@@ -486,7 +486,7 @@ Object.defineProperty (exports.oPreference.prototype, 'value', {
  */
 exports.oPreference.createPreference = function(category, keyword, type, value, description, descriptionText, prefObject){
   if (!prefObject.details.hasOwnProperty(keyword)){
-    var pref = new $.oPreference(category, keyword, type, value, description, descriptionText);
+    var pref = new this.$.oPreference(category, keyword, type, value, description, descriptionText);
     Object.defineProperty(prefObject, keyword,{
       enumerable: true,
       get : function(){

--- a/openHarmony/openHarmony_preferences.js
+++ b/openHarmony/openHarmony_preferences.js
@@ -61,7 +61,7 @@
  * pref["MyNewPreferenceName"];     // Provides: MyPreferenceValue
  * pref.get("MyNewPreferenceName"); // Provides: MyPreferenceValue
  */
-$.oPreferences = function( ){
+exports.oPreferences = function( ){
   this._type             = "preferences";
   this._addedPreferences = []
 
@@ -75,7 +75,7 @@ $.oPreferences = function( ){
  * @name $.oPreferences#refresh
  * @function
  */
-$.oPreferences.prototype.refresh = function(){
+exports.oPreferences.prototype.refresh = function(){
   var fl = specialFolders.userConfig + "/Harmony Premium-pref.xml";
   var nfl = new this.$.oFile( fl );
   if( !nfl.exists ){
@@ -262,7 +262,7 @@ $.oPreferences.prototype.refresh = function(){
  * @param   {string}                 name            The name of the new preference to create.
  * @param   {object}                 val             The value of the new preference created.
  */
-$.oPreferences.prototype.create = function( name, val ){
+exports.oPreferences.prototype.create = function( name, val ){
   if( this[ name ] ){
     throw ReferenceError( "Preference already exists by name: " + name );
   }
@@ -323,7 +323,7 @@ $.oPreferences.prototype.create = function( name, val ){
  * pref["MyNewPreferenceName"];     // Provides: undefined -- its not in the Harmony preference file.
  * pref.get("MyNewPreferenceName"); // Provides: MyPreferenceValue, its still available
  */
-$.oPreferences.prototype.get = function( name ){
+exports.oPreferences.prototype.get = function( name ){
   if( this[name] ){
     return this[name];
   }
@@ -410,7 +410,7 @@ $.oPreferences.prototype.get = function( name ){
  * // the preference object also holds a categories array with the list of all categories
  * log (prefs.categories)
  */
-$.oPreference = function(category, keyword, type, value, description, descriptionText){
+exports.oPreference = function(category, keyword, type, value, description, descriptionText){
   this.category = category;
   this.keyword = keyword;
   this.type = type;
@@ -424,7 +424,7 @@ $.oPreference = function(category, keyword, type, value, description, descriptio
  * get and set a preference value
  * @name $.oPreference#value
  */
-Object.defineProperty ($.oPreference.prototype, 'value', {
+Object.defineProperty (exports.oPreference.prototype, 'value', {
   get: function(){
     try{
       switch(this.type){
@@ -484,7 +484,7 @@ Object.defineProperty ($.oPreference.prototype, 'value', {
  * @param {string} descriptionText      The complete tooltip text for the preference
  * @param {Object} prefObject           The preference object that will receive the getter setter property (usually $.oApp._prefObject)
  */
-$.oPreference.createPreference = function(category, keyword, type, value, description, descriptionText, prefObject){
+exports.oPreference.createPreference = function(category, keyword, type, value, description, descriptionText, prefObject){
   if (!prefObject.details.hasOwnProperty(keyword)){
     var pref = new $.oPreference(category, keyword, type, value, description, descriptionText);
     Object.defineProperty(prefObject, keyword,{

--- a/openHarmony/openHarmony_scene.js
+++ b/openHarmony/openHarmony_scene.js
@@ -1464,7 +1464,7 @@ exports.oScene.prototype.addPalette = function(name, insertAtIndex, paletteStora
 
   // can fail if database lock wasn't released
   var _palette = new this.$.oPalette(_list.createPaletteAtLocation(_destination, storeInElement, name, insertAtIndex), _list);
-  log("created palette : "+_palette.path)
+  this.$.log("created palette : "+_palette.path)
   return _palette;
 }
 
@@ -1662,7 +1662,7 @@ exports.oScene.prototype.mergeNodes = function (nodes, resultName, deleteMerged)
     for (var i in _allNodes){
       // disable all nodes in the scene before merging unless given as argument
       if (selectedPaths.indexOf(_allNodes[i].path) != -1) {
-        $.log(_allNodes[i].path+" " +selectedPaths.indexOf(_allNodes[i].path));
+        this.$.log(_allNodes[i].path+" " +selectedPaths.indexOf(_allNodes[i].path));
         continue;
       }
       if (_allNodes[i].enabled){
@@ -1923,7 +1923,7 @@ exports.oScene.prototype.exportLayoutImage = function (path, includedNodes, expo
   if (typeof frameScale === 'undefined') var frameScale = 1;
   if (typeof frame === 'undefined') var frame = 1;
   if (typeof format === 'undefined') var format = "PNG4";
-  if (typeof path != this.$.oFile) path = new $.oFile(path);
+  if (typeof path != this.$.oFile) path = new this.$.oFile(path);
 
   var exporter = new LayoutExport();
   var params = new LayoutExportParams();
@@ -1981,8 +1981,8 @@ exports.oScene.prototype.exportPSD = function (path, margin, layersDescription){
     var _scene = this;
     var layersDescription = _allNodes.map(function(x){return ({layer: x, frame: _scene.currentFrame})})
   }
-  if (typeof path != this.$.oFile) path = new $.oFile(path)
-  var tempPath = new $.oFile(path.folder+"/"+path.name+"~")
+  if (typeof path != this.$.oFile) path = new this.$.oFile(path)
+  var tempPath = new this.$.oFile(path.folder+"/"+path.name+"~")
 
   var errors = [];
 
@@ -2018,7 +2018,7 @@ exports.oScene.prototype.exportPSD = function (path, margin, layersDescription){
   exporter.flush();
 
   if (path.exists) path.remove();
-  log(tempPath.exist+" "+tempPath);
+  this.$.log(tempPath.exist+" "+tempPath);
   tempPath.rename(path.name+".psd");
 }
 

--- a/openHarmony/openHarmony_scene.js
+++ b/openHarmony/openHarmony_scene.js
@@ -2109,7 +2109,7 @@ exports.oScene.prototype.exportQT = function (path, display, scale, exportSound,
   if (typeof scale === 'undefined') var scale = 1;
   if (typeof createThumbnail === 'undefined') var createThumbnail = true;
 
-  if (display instanceof oNode) display = display.name;
+  if (display instanceof this.$.oNode) display = display.name;
 
   var _startFrame = exportPreviewArea?scene.getStartFrame():1;
   var _stopFrame = exportPreviewArea?scene.getStopFrame():this.length;

--- a/openHarmony/openHarmony_scene.js
+++ b/openHarmony/openHarmony_scene.js
@@ -70,7 +70,7 @@
  *
  *
  */
-$.oScene = function( ){
+exports.oScene = function( ){
     // $.oScene.nodes property is a class property shared by all instances, so it can be passed by reference and always contain all nodes in the scene
 
     //var _topNode = new this.$.oNode("Top");
@@ -92,7 +92,7 @@ $.oScene = function( ){
  * @type {$.oFolder}
  * @readonly
  */
-Object.defineProperty($.oScene.prototype, 'path', {
+Object.defineProperty(exports.oScene.prototype, 'path', {
   get : function(){
     return new this.$.oFolder( scene.currentProjectPathRemapped() );
   }
@@ -104,7 +104,7 @@ Object.defineProperty($.oScene.prototype, 'path', {
  * @type {$.oFile}
  * @readonly
  */
-Object.defineProperty($.oScene.prototype, 'stage', {
+Object.defineProperty(exports.oScene.prototype, 'stage', {
   get : function(){
     if (this.online) return this.path + "/stage/" + this.name + ".stage";
     return this.path + "/" + this.version + ".xstage";
@@ -117,7 +117,7 @@ Object.defineProperty($.oScene.prototype, 'stage', {
  * @type {$.oFolder}
  * @readonly
  */
-Object.defineProperty($.oScene.prototype, 'paletteFolder', {
+Object.defineProperty(exports.oScene.prototype, 'paletteFolder', {
   get : function(){
     return new this.$.oFolder( this.path+"/palette-library" );
   }
@@ -131,7 +131,7 @@ Object.defineProperty($.oScene.prototype, 'paletteFolder', {
  * @type {$.oFolder}
  * @readonly
  */
-Object.defineProperty($.oScene.prototype, 'tempFolder', {
+Object.defineProperty(exports.oScene.prototype, 'tempFolder', {
   get : function(){
     if (!this.hasOwnProperty("_tempFolder")){
       this._tempFolder = new this.$.oFolder(scene.tempProjectPathRemapped());
@@ -147,7 +147,7 @@ Object.defineProperty($.oScene.prototype, 'tempFolder', {
  * @readonly
  * @type {string}
  */
-Object.defineProperty($.oScene.prototype, 'name', {
+Object.defineProperty(exports.oScene.prototype, 'name', {
   get : function(){
     return scene.currentScene();
   }
@@ -160,7 +160,7 @@ Object.defineProperty($.oScene.prototype, 'name', {
  * @readonly
  * @type {bool}
  */
-Object.defineProperty($.oScene.prototype, 'online', {
+Object.defineProperty(exports.oScene.prototype, 'online', {
   get : function(){
     return about.isDatabaseMode()
   }
@@ -172,7 +172,7 @@ Object.defineProperty($.oScene.prototype, 'online', {
  * @readonly
  * @type {string}
  */
-Object.defineProperty($.oScene.prototype, 'environnement', {
+Object.defineProperty(exports.oScene.prototype, 'environnement', {
   get : function(){
     if (!this.online) return null;
     return scene.currentEnvironment();
@@ -186,7 +186,7 @@ Object.defineProperty($.oScene.prototype, 'environnement', {
  * @readonly
  * @type {string}
  */
-Object.defineProperty($.oScene.prototype, 'job', {
+Object.defineProperty(exports.oScene.prototype, 'job', {
   get : function(){
     if (!this.online) return null;
     return scene.currentJob();
@@ -200,7 +200,7 @@ Object.defineProperty($.oScene.prototype, 'job', {
  * @readonly
  * @type {string}
  */
-Object.defineProperty($.oScene.prototype, 'version', {
+Object.defineProperty(exports.oScene.prototype, 'version', {
   get : function(){
     return scene.currentVersionName();
   }
@@ -214,7 +214,7 @@ Object.defineProperty($.oScene.prototype, 'version', {
  * @name $.oScene#sceneName
  * @type {string}
  */
-Object.defineProperty($.oScene.prototype, 'sceneName', {
+Object.defineProperty(exports.oScene.prototype, 'sceneName', {
   get : function(){
     return this.name;
   }
@@ -227,7 +227,7 @@ Object.defineProperty($.oScene.prototype, 'sceneName', {
  * @name $.oScene#startPreview
  * @type {int}
  */
-Object.defineProperty($.oScene.prototype, 'startPreview', {
+Object.defineProperty(exports.oScene.prototype, 'startPreview', {
   get : function(){
     return scene.getStartFrame();
   },
@@ -241,7 +241,7 @@ Object.defineProperty($.oScene.prototype, 'startPreview', {
  * @name $.oScene#stopPreview
  * @type {int}
  */
-Object.defineProperty($.oScene.prototype, 'stopPreview', {
+Object.defineProperty(exports.oScene.prototype, 'stopPreview', {
   get : function(){
     return scene.getStopFrame()+1;
   },
@@ -255,7 +255,7 @@ Object.defineProperty($.oScene.prototype, 'stopPreview', {
  * @name $.oScene#framerate
  * @type {float}
  */
-Object.defineProperty($.oScene.prototype, 'framerate', {
+Object.defineProperty(exports.oScene.prototype, 'framerate', {
   get : function(){
     return scene.getFrameRate();
   },
@@ -270,7 +270,7 @@ Object.defineProperty($.oScene.prototype, 'framerate', {
  * @name $.oScene#unitsAspectRatio
  * @type {double}
  */
- Object.defineProperty($.oScene.prototype, 'unitsAspectRatio', {
+ Object.defineProperty(exports.oScene.prototype, 'unitsAspectRatio', {
   get : function(){
     return this.aspectRatioX/this.aspectRatioY;
   }
@@ -282,7 +282,7 @@ Object.defineProperty($.oScene.prototype, 'framerate', {
  * @name $.oScene#aspectRatioX
  * @type {double}
  */
-Object.defineProperty($.oScene.prototype, 'aspectRatioX', {
+Object.defineProperty(exports.oScene.prototype, 'aspectRatioX', {
   get : function(){
     return scene.unitsAspectRatioX();
   },
@@ -296,7 +296,7 @@ Object.defineProperty($.oScene.prototype, 'aspectRatioX', {
  * @name $.oScene#aspectRatioY
  * @type {double}
  */
-Object.defineProperty($.oScene.prototype, 'aspectRatioY', {
+Object.defineProperty(exports.oScene.prototype, 'aspectRatioY', {
     get : function(){
         return scene.unitsAspectRatioY();
     },
@@ -310,7 +310,7 @@ Object.defineProperty($.oScene.prototype, 'aspectRatioY', {
  * @name $.oScene#unitsX
  * @type {double}
  */
-Object.defineProperty($.oScene.prototype, 'unitsX', {
+Object.defineProperty(exports.oScene.prototype, 'unitsX', {
     get : function(){
         return scene.numberOfUnitsX();
     },
@@ -324,7 +324,7 @@ Object.defineProperty($.oScene.prototype, 'unitsX', {
  * @name $.oScene#unitsY
  * @type {double}
  */
-Object.defineProperty($.oScene.prototype, 'unitsY', {
+Object.defineProperty(exports.oScene.prototype, 'unitsY', {
     get : function(){
         return scene.numberOfUnitsY();
     },
@@ -338,7 +338,7 @@ Object.defineProperty($.oScene.prototype, 'unitsY', {
  * @name $.oScene#unitsZ
  * @type {double}
  */
-Object.defineProperty($.oScene.prototype, 'unitsZ', {
+Object.defineProperty(exports.oScene.prototype, 'unitsZ', {
     get : function(){
         return scene.numberOfUnitsZ();
     },
@@ -353,7 +353,7 @@ Object.defineProperty($.oScene.prototype, 'unitsZ', {
  * @name $.oScene#center
  * @type {$.oPoint}
  */
-Object.defineProperty($.oScene.prototype, 'center', {
+Object.defineProperty(exports.oScene.prototype, 'center', {
     get : function(){
         return new this.$.oPoint( scene.coordAtCenterX(), scene.coordAtCenterY(), 0.0 );
     },
@@ -369,7 +369,7 @@ Object.defineProperty($.oScene.prototype, 'center', {
  * @type {double}
  * @readonly
  */
-Object.defineProperty($.oScene.prototype, 'fieldVectorResolutionX', {
+Object.defineProperty(exports.oScene.prototype, 'fieldVectorResolutionX', {
   get : function(){
     var yUnit = this.fieldVectorResolutionY;
     var unit = yUnit * this.unitsAspectRatio;
@@ -384,7 +384,7 @@ Object.defineProperty($.oScene.prototype, 'fieldVectorResolutionX', {
  * @type {double}
  * @readonly
  */
-Object.defineProperty($.oScene.prototype, 'fieldVectorResolutionY', {
+Object.defineProperty(exports.oScene.prototype, 'fieldVectorResolutionY', {
   get : function(){
     var verticalResolution = 1875 // the amount of drawing units for the max vertical field value
     var unit = verticalResolution/12; // the vertical number of units on drawings is always 12 regardless of $.scn.unitsY
@@ -399,7 +399,7 @@ Object.defineProperty($.oScene.prototype, 'fieldVectorResolutionY', {
  * @readonly
  * @type {int}
  */
-Object.defineProperty($.oScene.prototype, 'resolutionX', {
+Object.defineProperty(exports.oScene.prototype, 'resolutionX', {
     get : function(){
         return scene.currentResolutionX();
     }
@@ -410,7 +410,7 @@ Object.defineProperty($.oScene.prototype, 'resolutionX', {
  * @name $.oScene#resolutionY
  * @type {int}
  */
-Object.defineProperty($.oScene.prototype, 'resolutionY', {
+Object.defineProperty(exports.oScene.prototype, 'resolutionY', {
     get : function(){
         return scene.currentResolutionY();
     }
@@ -421,7 +421,7 @@ Object.defineProperty($.oScene.prototype, 'resolutionY', {
  * @name $.oScene#defaultResolutionX
  * @type {int}
  */
-Object.defineProperty($.oScene.prototype, 'defaultResolutionX', {
+Object.defineProperty(exports.oScene.prototype, 'defaultResolutionX', {
     get : function(){
         return scene.defaultResolutionX();
     },
@@ -435,7 +435,7 @@ Object.defineProperty($.oScene.prototype, 'defaultResolutionX', {
  * @name $.oScene#defaultResolutionY
  * @type {int}
  */
-Object.defineProperty($.oScene.prototype, 'defaultResolutionY', {
+Object.defineProperty(exports.oScene.prototype, 'defaultResolutionY', {
     get : function(){
         return scene.defaultResolutionY();
     },
@@ -449,7 +449,7 @@ Object.defineProperty($.oScene.prototype, 'defaultResolutionY', {
  * @name $.oScene#fov
  * @type {double}
  */
-Object.defineProperty($.oScene.prototype, 'fov', {
+Object.defineProperty(exports.oScene.prototype, 'fov', {
     get : function(){
         return scene.defaultResolutionFOV();
     },
@@ -464,7 +464,7 @@ Object.defineProperty($.oScene.prototype, 'fov', {
  * @name $.oScene#defaultDisplay
  * @type {oNode}
  */
-Object.defineProperty($.oScene.prototype, 'defaultDisplay', {
+Object.defineProperty(exports.oScene.prototype, 'defaultDisplay', {
   get : function(){
     return this.getNodeByPath(scene.getDefaultDisplay());
   },
@@ -481,7 +481,7 @@ Object.defineProperty($.oScene.prototype, 'defaultDisplay', {
  * @readonly
  * @type {bool}
  */
-Object.defineProperty($.oScene.prototype, 'unsaved', {
+Object.defineProperty(exports.oScene.prototype, 'unsaved', {
     get : function(){
         return scene.isDirty();
     }
@@ -494,7 +494,7 @@ Object.defineProperty($.oScene.prototype, 'unsaved', {
  * @type {$.oGroupNode}
  * @readonly
  */
-Object.defineProperty($.oScene.prototype, 'root', {
+Object.defineProperty(exports.oScene.prototype, 'root', {
     get : function(){
         var _topNode = this.getNodeByPath( "Top" );
         return _topNode
@@ -508,7 +508,7 @@ Object.defineProperty($.oScene.prototype, 'root', {
  * @readonly
  * @type {$.oNode[]}
  */
-Object.defineProperty($.oScene.prototype, 'nodes', {
+Object.defineProperty(exports.oScene.prototype, 'nodes', {
     get : function(){
         var _topNode = this.root;
         return _topNode.subNodes( true );
@@ -523,7 +523,7 @@ Object.defineProperty($.oScene.prototype, 'nodes', {
  * @type {$.oColumn[]}
  * @todo add attribute finding to get complete column objects
  */
-Object.defineProperty($.oScene.prototype, 'columns', {
+Object.defineProperty(exports.oScene.prototype, 'columns', {
     get : function(){
         var _columns = [];
         for (var i=0; i<column.numberOf(); i++){
@@ -543,7 +543,7 @@ Object.defineProperty($.oScene.prototype, 'columns', {
  * @readonly
  * @type {$.oPalette[]}
  */
-Object.defineProperty($.oScene.prototype, 'palettes', {
+Object.defineProperty(exports.oScene.prototype, 'palettes', {
   get : function(){
     var _paletteList = PaletteObjectManager.getScenePaletteList();
 
@@ -562,7 +562,7 @@ Object.defineProperty($.oScene.prototype, 'palettes', {
  * @readonly
  * @type {$.oElement[]}
  */
-Object.defineProperty($.oScene.prototype, 'elements', {
+Object.defineProperty(exports.oScene.prototype, 'elements', {
   get : function(){
     var _elements = [];
     var _ids = {};
@@ -617,7 +617,7 @@ Object.defineProperty($.oScene.prototype, 'elements', {
  * @name $.oScene#length
  * @type {int}
  */
-Object.defineProperty($.oScene.prototype, 'length', {
+Object.defineProperty(exports.oScene.prototype, 'length', {
     get : function(){
         return frame.numberOf()
     },
@@ -639,7 +639,7 @@ Object.defineProperty($.oScene.prototype, 'length', {
  * @name $.oScene#currentFrame
  * @type {int}
  */
-Object.defineProperty($.oScene.prototype, 'currentFrame', {
+Object.defineProperty(exports.oScene.prototype, 'currentFrame', {
     get : function(){
         return frame.current();
     },
@@ -655,7 +655,7 @@ Object.defineProperty($.oScene.prototype, 'currentFrame', {
  * @name $.oScene#selectedNodes
  * @type {$.oNode[]}
  */
-Object.defineProperty($.oScene.prototype, 'selectedNodes', {
+Object.defineProperty(exports.oScene.prototype, 'selectedNodes', {
   get : function(){
     return this.getSelectedNodes();
   },
@@ -674,7 +674,7 @@ Object.defineProperty($.oScene.prototype, 'selectedNodes', {
  * @name $.oScene#selectedFrames
  * @type {int[]}
  */
-Object.defineProperty($.oScene.prototype, 'selectedFrames', {
+Object.defineProperty(exports.oScene.prototype, 'selectedFrames', {
   get : function(){
     if (selection.isSelectionRange()){
       var _selectedFrames = [selection.startFrame(), selection.startFrame()+selection.numberOfFrames()];
@@ -696,7 +696,7 @@ Object.defineProperty($.oScene.prototype, 'selectedFrames', {
  * @name $.oScene#selectedPalette
  * @type {$.oPalette}
  */
-Object.defineProperty($.oScene.prototype, "selectedPalette", {
+Object.defineProperty(exports.oScene.prototype, "selectedPalette", {
   get: function(){
     var _paletteList = PaletteObjectManager.getScenePaletteList()
     var _id = PaletteManager.getCurrentPaletteId()
@@ -717,7 +717,7 @@ Object.defineProperty($.oScene.prototype, "selectedPalette", {
  * @name $.oScene#selectedShapes
  * @type {$.oStroke[]}
  */
-Object.defineProperty($.oScene.prototype, "selectedShapes", {
+Object.defineProperty(exports.oScene.prototype, "selectedShapes", {
   get : function(){
     var _currentDrawing = this.activeDrawing;
     var _shapes = _currentDrawing.selectedShapes;
@@ -732,7 +732,7 @@ Object.defineProperty($.oScene.prototype, "selectedShapes", {
  * @name $.oScene#selectedStrokes
  * @type {$.oStroke[]}
  */
-Object.defineProperty($.oScene.prototype, "selectedStrokes", {
+Object.defineProperty(exports.oScene.prototype, "selectedStrokes", {
   get : function(){
     var _currentDrawing = this.activeDrawing;
     var _strokes = _currentDrawing.selectedStrokes;
@@ -747,7 +747,7 @@ Object.defineProperty($.oScene.prototype, "selectedStrokes", {
  * @name $.oScene#selectedContours
  * @type {$.oContour[]}
  */
-Object.defineProperty($.oScene.prototype, "selectedContours", {
+Object.defineProperty(exports.oScene.prototype, "selectedContours", {
   get : function(){
     var _currentDrawing = this.activeDrawing;
     var _strokes = _currentDrawing.selectedContours;
@@ -762,7 +762,7 @@ Object.defineProperty($.oScene.prototype, "selectedContours", {
  * @name $.oScene#activeDrawing
  * @type {$.oDrawing}
  */
-Object.defineProperty($.oScene.prototype, 'activeDrawing', {
+Object.defineProperty(exports.oScene.prototype, 'activeDrawing', {
   get : function(){
     var _settings = Tools.getToolSettings();
     var _drawingNodes = this.getSelectedNodesOfType("READ", false);;
@@ -793,7 +793,7 @@ Object.defineProperty($.oScene.prototype, 'activeDrawing', {
  * @type {$.oTimeline}
  * @readonly
  */
-Object.defineProperty($.oScene.prototype, 'currentTimeline', {
+Object.defineProperty(exports.oScene.prototype, 'currentTimeline', {
   get : function(){
     if (!this.hasOwnProperty("_timeline")){
       this._timeline = this.getTimeline();
@@ -817,7 +817,7 @@ Object.defineProperty($.oScene.prototype, 'currentTimeline', {
  *
  * @return {$.oNode}                    The node found given the query.
  */
-$.oScene.prototype.getNodeByPath = function(fullPath){
+exports.oScene.prototype.getNodeByPath = function(fullPath){
     var _type = node.type(fullPath);
     if (_type == "") return null;
 
@@ -851,7 +851,7 @@ $.oScene.prototype.getNodeByPath = function(fullPath){
  *
  * @return  {$.oNode[]}     The nodes found.
  */
-$.oScene.prototype.getNodesByType = function(typeName){
+exports.oScene.prototype.getNodesByType = function(typeName){
   return this.root.getNodesByType(typeName, true);
 }
 
@@ -862,7 +862,7 @@ $.oScene.prototype.getNodesByType = function(typeName){
  *
  * @return  {$.oNode[]}     The nodes found.
  */
- $.oScene.prototype.getSelectedNodesOfType = function(types, recurse){
+ exports.oScene.prototype.getSelectedNodesOfType = function(types, recurse){
   if (!(types instanceof Array)) types = [types];
   if (typeof recurse === "undefined") var recurse = false;
   return this.getSelectedNodes(recurse).filter(function(x){return types.indexOf(x.type) != -1});
@@ -877,7 +877,7 @@ $.oScene.prototype.getNodesByType = function(typeName){
  *
  * @return {$.oColumn}                    The column found given the query.
  */
-$.oScene.prototype.getColumnByName = function( uniqueName, oAttributeObject ){
+exports.oScene.prototype.getColumnByName = function( uniqueName, oAttributeObject ){
     var _type = column.type(uniqueName);
 
     switch (_type) {
@@ -898,7 +898,7 @@ $.oScene.prototype.getColumnByName = function( uniqueName, oAttributeObject ){
  *
  * @return {$.oElement}                               The element found given the query. In case of an element linked to several column, only the first one will be returned, unless the column is specified
  */
-$.oScene.prototype.getElementById = function( id, oColumnObject ){
+exports.oScene.prototype.getElementById = function( id, oColumnObject ){
   if (element.getNameById(id) == "") return null;
 
   var _sceneElements = this.elements.filter(function(x){return x.id == id});
@@ -915,7 +915,7 @@ $.oScene.prototype.getElementById = function( id, oColumnObject ){
  *
  * @return {$.oNode[]}                 The selected nodes.
  */
-$.oScene.prototype.getSelectedNodes = function( recurse, sortResult ){
+exports.oScene.prototype.getSelectedNodes = function( recurse, sortResult ){
     if (typeof recurse === 'undefined') var recurse = false;
     if (typeof sort_result === 'undefined') var sortResult = false;     //Avoid sorting, save time, if unnecessary and used internally.
 
@@ -948,7 +948,7 @@ $.oScene.prototype.getSelectedNodes = function( recurse, sortResult ){
  *
  * @return {$.oNode[]}                 The node[s] found given the query.
  */
-$.oScene.prototype.nodeSearch = function( query, sort_result ){
+exports.oScene.prototype.nodeSearch = function( query, sort_result ){
   if (typeof sort_result    === 'undefined') var sort_result = true;     //Avoid sorting, save time, if unnecessary and used internally.
 
   //-----------------------------------
@@ -1241,7 +1241,7 @@ $.oScene.prototype.nodeSearch = function( query, sort_result ){
  *
  * @return {$.oNode}   The created node
  */
-$.oScene.prototype.addNode = function( type, name, group, nodePosition ){
+exports.oScene.prototype.addNode = function( type, name, group, nodePosition ){
   var _group = (group instanceof this.$.oGroupNode)?group:this.$node(group);
 
   if (_group != null && _group instanceof this.$.oGroupNode){
@@ -1264,7 +1264,7 @@ $.oScene.prototype.addNode = function( type, name, group, nodePosition ){
  * @return {$.oColumn}  The created column
  */
 
-$.oScene.prototype.addColumn = function( type, name, oElementObject ){
+exports.oScene.prototype.addColumn = function( type, name, oElementObject ){
     // Defaults for optional parameters
     if (!type) throw new Error ("Must provide a type when creating a new column.");
 
@@ -1311,7 +1311,7 @@ $.oScene.prototype.addColumn = function( type, name, oElementObject ){
  *
  * @return {$.oElement}  The created element
  */
-$.oScene.prototype.addElement = function(name, imageFormat, fieldGuide, scanType){
+exports.oScene.prototype.addElement = function(name, imageFormat, fieldGuide, scanType){
     // Defaults for optional parameters
     if (typeof scanType === 'undefined') var scanType = "COLOR";
     if (typeof fieldGuide === 'undefined') var fieldGuide = 12;
@@ -1344,7 +1344,7 @@ $.oScene.prototype.addElement = function(name, imageFormat, fieldGuide, scanType
 
  * @return {$.oDrawingNode}     The created node.
  */
-$.oScene.prototype.addDrawingNode = function( name, group, nodePosition, oElementObject, drawingColumn, options ){
+exports.oScene.prototype.addDrawingNode = function( name, group, nodePosition, oElementObject, drawingColumn, options ){
   var _group = (group instanceof this.$.oGroupNode)?group:this.$node(group);
 
   if (_group != null && _group instanceof this.$.oGroupNode){
@@ -1369,7 +1369,7 @@ $.oScene.prototype.addDrawingNode = function( name, group, nodePosition, oElemen
 
  * @return {$.oGroupNode}   The created node.
  */
-$.oScene.prototype.addGroup = function( name, includeNodes, addComposite, addPeg, group, nodePosition ){
+exports.oScene.prototype.addGroup = function( name, includeNodes, addComposite, addPeg, group, nodePosition ){
   var _group = (group instanceof this.$.oGroupNode)?group:this.$node(group);
 
   if (_group != null && _group instanceof this.$.oGroupNode){
@@ -1388,7 +1388,7 @@ $.oScene.prototype.addGroup = function( name, includeNodes, addComposite, addPeg
  * @param   {string}        [display]                The display node to build the timeline for.
  * @return {$.oTimeline}    The timelne object given the display.
  */
-$.oScene.prototype.getTimeline = function(display){
+exports.oScene.prototype.getTimeline = function(display){
     return new this.$.oTimeline( display, this );
 }
 
@@ -1399,7 +1399,7 @@ $.oScene.prototype.getTimeline = function(display){
  *
  * @return  {$.oPalette}                 The oPalette found given the query.
  */
-$.oScene.prototype.getPaletteByName = function(name){
+exports.oScene.prototype.getPaletteByName = function(name){
   var _palettes = this.palettes;
   for (var i in _palettes){
     if (_palettes[i].name == name) return _palettes[i];
@@ -1412,7 +1412,7 @@ $.oScene.prototype.getPaletteByName = function(name){
  * @param   {string}   path              The palette path to find.
  * @return  {$.oPalette}                 The oPalette or null if not found.
  */
-$.oScene.prototype.getPaletteByPath = function(path){
+exports.oScene.prototype.getPaletteByPath = function(path){
   var _palettes = this.palettes;
   for (var i in _palettes){
     if (_palettes[i].path.path == path) return _palettes[i];
@@ -1426,7 +1426,7 @@ $.oScene.prototype.getPaletteByPath = function(path){
  * @return {$.oPalette}   oPalette with provided name.
  * @deprecated
  */
-$.oScene.prototype.getSelectedPalette = function(){
+exports.oScene.prototype.getSelectedPalette = function(){
     var _paletteList = PaletteManager.getScenePaletteList();
     var _id = PaletteManager.getCurrentPaletteId()
     var _palette = new this.$.oPalette(_paletteList.getPaletteById(_id), _paletteList);
@@ -1443,7 +1443,7 @@ $.oScene.prototype.getSelectedPalette = function(){
  *
  * @return {$.oPalette}   newly created oPalette with provided name.
  */
-$.oScene.prototype.addPalette = function(name, insertAtIndex, paletteStorage, storeInElement){
+exports.oScene.prototype.addPalette = function(name, insertAtIndex, paletteStorage, storeInElement){
   if (typeof paletteStorage === 'undefined') var paletteStorage = "scene";
   if (typeof insertAtIndex === 'undefined') var insertAtIndex = 0;
 
@@ -1480,7 +1480,7 @@ $.oScene.prototype.addPalette = function(name, insertAtIndex, paletteStorage, st
  *
  * @return {$.oPalette}   oPalette with provided name.
  */
-$.oScene.prototype.importPalette = function(filename, name, index, paletteStorage, storeInElement){
+exports.oScene.prototype.importPalette = function(filename, name, index, paletteStorage, storeInElement){
   var _paletteFile = new this.$.oFile(filename);
   if (!_paletteFile.exists){
     throw new Error ("Cannot import palette from file "+filename+" because it doesn't exist", this.$.DEBUG_LEVEL.ERROR);
@@ -1547,7 +1547,7 @@ $.oScene.prototype.importPalette = function(filename, name, index, paletteStorag
  *
  * @return       {$.oLink[]}      An array of unique links existing between the nodes.
  */
-$.oScene.prototype.createPaletteFromNodes = function(nodes, paletteName, colorName){
+exports.oScene.prototype.createPaletteFromNodes = function(nodes, paletteName, colorName){
   if (typeof paletteName === 'undefined') var paletteName = this.name;
   if (typeof colorName ==='undefined') var colorName = false;
 
@@ -1580,7 +1580,7 @@ $.oScene.prototype.createPaletteFromNodes = function(nodes, paletteName, colorNa
  *
  * @return  {$.oLink[]}      An array of unique links existing between the nodes.
  */
-$.oScene.prototype.getNodesLinks = function (nodes){
+exports.oScene.prototype.getNodesLinks = function (nodes){
   var _links = [];
   var _linkStrings = [];
   // var _nodePaths = nodes.map(function(x){return x.path});
@@ -1631,7 +1631,7 @@ $.oScene.prototype.getNodesLinks = function (nodes){
  *
  * @return {$.oNode}        The resulting drawing node from the merge.
  */
-$.oScene.prototype.mergeNodes = function (nodes, resultName, deleteMerged){
+exports.oScene.prototype.mergeNodes = function (nodes, resultName, deleteMerged){
     this.$.beginUndo("oh_mergeNodes");
     // TODO: is there a way to do this without Action.perform?
     // pass a oNode object as argument for destination node instead of name/group?
@@ -1776,7 +1776,7 @@ $.oScene.prototype.mergeNodes = function (nodes, resultName, deleteMerged){
  *
  * $.endUndo();
  */
-$.oScene.prototype.exportTemplate = function(nodes, exportPath, exportPalettesMode, renameUsedColors, copyOptions){
+exports.oScene.prototype.exportTemplate = function(nodes, exportPath, exportPalettesMode, renameUsedColors, copyOptions){
   if (typeof exportPalettesMode === 'undefined') var exportPalettesMode = "usedOnly";
   if (typeof copyOptions === 'undefined') var copyOptions = copyPaste.getCurrentCreateOptions();
   if (typeof renameUsedColors === 'undefined') var renameUsedColors = false;
@@ -1893,7 +1893,7 @@ $.oScene.prototype.exportTemplate = function(nodes, exportPath, exportPalettesMo
  *
  * @return {$.oNode[]}         The resulting pasted nodes.
  */
-$.oScene.prototype.importTemplate = function( tplPath, group, destinationNodes, extendScene, nodePosition, pasteOptions ){
+exports.oScene.prototype.importTemplate = function( tplPath, group, destinationNodes, extendScene, nodePosition, pasteOptions ){
   if (typeof group === 'undefined') var group = this.root;
   var _group = (group instanceof this.$.oGroupNode)?group:this.$node(group);
 
@@ -1916,7 +1916,7 @@ $.oScene.prototype.importTemplate = function( tplPath, group, destinationNodes, 
  * @param {bool}     [exportBackground=false]    Whether to add a white background.
  * @param {float}    [frameScale=1]              A factor by which to scale the frame. ex: 1.05 will add a 10% margin (5% on both sides)
  */
-$.oScene.prototype.exportLayoutImage = function (path, includedNodes, exportFrame, exportCameraFrame, exportBackground, frameScale, format){
+exports.oScene.prototype.exportLayoutImage = function (path, includedNodes, exportFrame, exportCameraFrame, exportBackground, frameScale, format){
   if (typeof includedNodes === 'undefined') var includedNodes = [];
   if (typeof exportCameraFrame === 'undefined') var exportCameraFrame = false;
   if (typeof exportBackground === 'undefined') var exportBackground = false;
@@ -1971,7 +1971,7 @@ $.oScene.prototype.exportLayoutImage = function (path, includedNodes, exportFram
  * @param {float}    margin                    a factor by which to increase the rendering area. for example, 1.05 creates a 10% margin. (5% on each side)
  * @param {Object[]} layersDescription          must be an array of objects {layer: $.oNode, frame: int} which describe all the images to export. By default, will include all visible layers of the timeline.
  */
-$.oScene.prototype.exportPSD = function (path, margin, layersDescription){
+exports.oScene.prototype.exportPSD = function (path, margin, layersDescription){
   if (typeof margin === 'undefined') var margin = 1;
   if (typeof layersDescription === 'undefined') {
     // export the current frame for each drawing layer present in the default timeline.
@@ -2036,7 +2036,7 @@ $.oScene.prototype.exportPSD = function (path, margin, layersDescription){
  *
  * @return {$.oNode[]}     The nodes being created as part of the PSD import.
  */
-$.oScene.prototype.importPSD = function( path, group, nodePosition, separateLayers, addPeg, addComposite, alignment ){
+exports.oScene.prototype.importPSD = function( path, group, nodePosition, separateLayers, addPeg, addComposite, alignment ){
   if (typeof group === 'undefined') var group = this.root;
   var _group = (group instanceof this.$.oGroupNode)?group:this.$node(group);
 
@@ -2058,7 +2058,7 @@ $.oScene.prototype.importPSD = function( path, group, nodePosition, separateLaye
  *
  * @returns {$.oNode[]}    The nodes affected by the update
  */
-$.oScene.prototype.updatePSD = function( path, group, separateLayers ){
+exports.oScene.prototype.updatePSD = function( path, group, separateLayers ){
   if (typeof group === 'undefined') var group = this.root;
   var _group = (group instanceof this.$.oGroupNode)?group:this.$node(group);
 
@@ -2079,7 +2079,7 @@ $.oScene.prototype.updatePSD = function( path, group, separateLayers ){
  *
  * @return {$.oNode}        The imported sound column.
  */
- $.oScene.prototype.importSound = function(path, layerName){
+ exports.oScene.prototype.importSound = function(path, layerName){
    var _audioFile = new this.$.oFile(path);
    if (typeof layerName === 'undefined') var layerName = _audioFile.name;
 
@@ -2102,7 +2102,7 @@ $.oScene.prototype.updatePSD = function( path, group, separateLayers ){
 *
 * @return {bool}        The success of the export
 */
-$.oScene.prototype.exportQT = function (path, display, scale, exportSound, exportPreviewArea, createThumbnail){
+exports.oScene.prototype.exportQT = function (path, display, scale, exportSound, exportPreviewArea, createThumbnail){
   if (typeof display === 'undefined') var display = node.getName(node.getNodes(["DISPLAY"])[0]);
   if (typeof exportSound === 'undefined') var exportSound = true;
   if (typeof exportPreviewArea === 'undefined') var exportPreviewArea = false;
@@ -2132,7 +2132,7 @@ $.oScene.prototype.exportQT = function (path, display, scale, exportSound, expor
  *
  * @return {$.oNode}        The imported Quicktime Node.
  */
-$.oScene.prototype.importQT = function( path, group, importSound, nodePosition, extendScene, alignment, convertToTvg ){
+exports.oScene.prototype.importQT = function( path, group, importSound, nodePosition, extendScene, alignment, convertToTvg ){
   if (typeof group === 'undefined') var group = this.root;
   var _group = (group instanceof this.$.oGroupNode)?group:this.$node(group);
 
@@ -2160,7 +2160,7 @@ $.oScene.prototype.importQT = function( path, group, importSound, nodePosition, 
  *
  * @return {$.oBackdrop}       The created backdrop.
  */
-$.oScene.prototype.addBackdrop = function( groupPath, title, body, color, x, y, width, height ){
+exports.oScene.prototype.addBackdrop = function( groupPath, title, body, color, x, y, width, height ){
   if (typeof group === 'undefined') var group = this.root;
   var _group = (group instanceof this.$.oGroupNode)?group:this.$node(group);
 
@@ -2189,7 +2189,7 @@ $.oScene.prototype.addBackdrop = function( groupPath, title, body, color, x, y, 
  *
  * @return {$.oBackdrop}       The created backdrop.
  */
-$.oScene.prototype.addBackdropToNodes = function( groupPath, nodes, title, body, color, x, y, width, height ){
+exports.oScene.prototype.addBackdropToNodes = function( groupPath, nodes, title, body, color, x, y, width, height ){
   if (typeof group === 'undefined') var group = this.root;
   var _group = (group instanceof this.$.oGroupNode)?group:this.$node(group);
 
@@ -2206,7 +2206,7 @@ $.oScene.prototype.addBackdropToNodes = function( groupPath, nodes, title, body,
 /**
  * Saves the scene.
  */
-$.oScene.prototype.save = function( ){
+exports.oScene.prototype.save = function( ){
   scene.saveAll();
 }
 
@@ -2215,7 +2215,7 @@ $.oScene.prototype.save = function( ){
  * Saves the scene in a different location (only available on offline scenes).
  * @param {string} newPath    the new location for the scene (must be a folder path and not a .xstage)
  */
-$.oScene.prototype.saveAs = function(newPath){
+exports.oScene.prototype.saveAs = function(newPath){
   if (this.online) {
     this.$.debug("Can't use saveAs() in database mode.", this.$.DEBUG_LEVEL.ERROR);
     return;
@@ -2231,7 +2231,7 @@ $.oScene.prototype.saveAs = function(newPath){
  * @param {string}      newVersionName      The name for the new version
  * @param {bool}        markAsDefault       Wether to make this new version the default version that will be opened from the database.
  */
-$.oScene.prototype.saveNewVersion = function(newVersionName, markAsDefault){
+exports.oScene.prototype.saveNewVersion = function(newVersionName, markAsDefault){
   if (typeof markAsDefault === 'undefined') var markAsDefault = true;
 
   return scene.saveAsNewVersion (newVersionName, markAsDefault);
@@ -2249,7 +2249,7 @@ $.oScene.prototype.saveNewVersion = function(newVersionName, markAsDefault){
  * @param {string} [postRenderScript]           The path to the script to execute on the scene after the render is finished
  * @return {$.oProcess} In case of using renderInBackground, will return the oProcess object doing the render
  */
-$.oScene.prototype.renderWriteNodes = function(renderInBackground, startFrame, endFrame, resX, resY, preRenderScript, postRenderScript){
+exports.oScene.prototype.renderWriteNodes = function(renderInBackground, startFrame, endFrame, resX, resY, preRenderScript, postRenderScript){
   if (typeof renderInBackground === 'undefined') var renderInBackground = true;
   if (typeof startFrame === 'undefined') var startFrame = 1;
   if (typeof endFrame === 'undefined') var endFrame = this.length+1;
@@ -2339,7 +2339,7 @@ $.oScene.prototype.renderWriteNodes = function(renderInBackground, startFrame, e
  * Closes the scene.
  * @param   {bool}            [exit]                                       Whether it should exit after closing.
  */
-$.oScene.prototype.close = function( exit ){
+exports.oScene.prototype.close = function( exit ){
   if (typeof nodePosition === 'undefined') exit = false;
 
   if( exit ){
@@ -2354,7 +2354,7 @@ $.oScene.prototype.close = function( exit ){
  *
  * @return {Matrix4x4}          The matrix of the camera.
  */
-$.oScene.prototype.getCameraMatrix = function( ){
+exports.oScene.prototype.getCameraMatrix = function( ){
     return scene.getCameraMatrix();
 }
 
@@ -2363,7 +2363,7 @@ $.oScene.prototype.getCameraMatrix = function( ){
  *
  * @return {Matrix4x4}          The projection matrix of the camera/scene.
  */
-$.oScene.prototype.getProjectionMatrix = function( ){
+exports.oScene.prototype.getProjectionMatrix = function( ){
   var fov = this.fov;
   var f   = scene.toOGL( new Point3d( 0.0, 0.0, this.unitsZ ) ).z;
   var n   = 0.00001;
@@ -2392,7 +2392,7 @@ $.oScene.prototype.getProjectionMatrix = function( ){
  * @see $.oMetadata
  * @return {$.oMetadata}          The metadata of the scene.
  */
-$.oScene.prototype.getMetadata = function( ){
+exports.oScene.prototype.getMetadata = function( ){
   return new this.$.oMetadata( );
 }
 
@@ -2405,7 +2405,7 @@ $.oScene.prototype.getMetadata = function( ){
  *
  * @return  {$.oNode}                     The node found given the query.
  */
-$.oScene.prototype.$node = function( fullPath ){
+exports.oScene.prototype.$node = function( fullPath ){
     return this.getNodeByPath( fullPath );
 }
 
@@ -2416,7 +2416,7 @@ $.oScene.prototype.$node = function( fullPath ){
  *
  * @return {$.oColumn}          The node found given the query.
  */
-$.oScene.prototype.$column = function( uniqueName, oAttributeObject ){
+exports.oScene.prototype.$column = function( uniqueName, oAttributeObject ){
     return this.getColumnByName( uniqueName, oAttributeObject );
 }
 
@@ -2427,6 +2427,6 @@ $.oScene.prototype.$column = function( uniqueName, oAttributeObject ){
  *
  * @return  {$.oPalette}               The node found given the query.
  */
-$.oScene.prototype.$palette = function( name ){
+exports.oScene.prototype.$palette = function( name ){
     return this.getPaletteByName( name );
 }

--- a/openHarmony/openHarmony_threading.js
+++ b/openHarmony/openHarmony_threading.js
@@ -68,7 +68,7 @@
  * @property {bool}                    started               The start state of all threads.
  * @property {int}                     timeout               MS timeout for blocking processes.
  */
-$.oThread = function( kernel, list, threadCount, start, timeout, reserveThread ){
+exports.oThread = function( kernel, list, threadCount, start, timeout, reserveThread ){
   if (typeof threadCount === 'undefined') var threadCount = "2";
   if (typeof start === 'undefined') var start = false;
   if (typeof reserveThread === 'undefined') reserveThread = true;
@@ -132,7 +132,7 @@ $.oThread = function( kernel, list, threadCount, start, timeout, reserveThread )
  * @name $.oThread#complete
  * @type {bool}
  */
-Object.defineProperty($.oThread.prototype, 'complete', {
+Object.defineProperty(exports.oThread.prototype, 'complete', {
     get : function(){
         if( !this.started ){
           System.println( "Not yet started" );
@@ -154,7 +154,7 @@ Object.defineProperty($.oThread.prototype, 'complete', {
  * @name $.oThread#completedIndices
  * @type {int[]}
  */
-Object.defineProperty($.oThread.prototype, 'completedIndices', {
+Object.defineProperty(exports.oThread.prototype, 'completedIndices', {
     get : function(){
         var indices = [];
         for( var n=0;n<this.complete_thread.length;n++ ){
@@ -172,7 +172,7 @@ Object.defineProperty($.oThread.prototype, 'completedIndices', {
  * @name $.oThread#errorsWithIndex
  * @type {object[]}
  */
-Object.defineProperty($.oThread.prototype, 'errorsWithIndex', {
+Object.defineProperty(exports.oThread.prototype, 'errorsWithIndex', {
     get : function(){
         var errors = [];
         for( var n=0;n<this.error_thread.length;n++ ){
@@ -190,7 +190,7 @@ Object.defineProperty($.oThread.prototype, 'errorsWithIndex', {
  * @name $.oThread#resultsWithIndex
  * @type {object[]}
  */
-Object.defineProperty($.oThread.prototype, 'resultsWithIndex', {
+Object.defineProperty(exports.oThread.prototype, 'resultsWithIndex', {
     get : function(){
         var results = [];
         for( var n=0;n<this.results_thread.length;n++ ){
@@ -208,7 +208,7 @@ Object.defineProperty($.oThread.prototype, 'resultsWithIndex', {
  * @name $.oThread#errors
  * @type {string[]}
  */
-Object.defineProperty($.oThread.prototype, 'errors', {
+Object.defineProperty(exports.oThread.prototype, 'errors', {
     get : function(){
       return this.error_thread;
     }
@@ -219,7 +219,7 @@ Object.defineProperty($.oThread.prototype, 'errors', {
  * @name $.oThread#results
  * @type {object[]}
  */
-Object.defineProperty($.oThread.prototype, 'results', {
+Object.defineProperty(exports.oThread.prototype, 'results', {
     get : function(){
       return this.results_thread;
     }
@@ -230,7 +230,7 @@ Object.defineProperty($.oThread.prototype, 'results', {
  * Start the thread and block if necessary.
  * @param   {bool}         block                    Whether the process should block and wait for completion.
  */
-$.oThread.prototype.start = function( block ){
+exports.oThread.prototype.start = function( block ){
   if (typeof block === 'undefined') block = true;
 
   if( !this.threads_available ){
@@ -263,7 +263,7 @@ $.oThread.prototype.start = function( block ){
  * If threads are not yet prepared, this will prepare them.
  * @param   {bool}         [block]                    Whether the process should block and wait for completion.
  */
-$.oThread.prototype.prepareThreads = function( start ){
+exports.oThread.prototype.prepareThreads = function( start ){
   if (start) this.startAtInstantiation = start;
 
   if( this.threads_available ){
@@ -306,7 +306,7 @@ $.oThread.prototype.prepareThreads = function( start ){
  * If started, will block until completion or timeout.
  * @param   {int}         block_time                    The MS time to block.
  */
-$.oThread.prototype.wait = function( block_time ){
+exports.oThread.prototype.wait = function( block_time ){
     if ( block_time ) this.timeout = block_time;
 
     if( this.reserveThread && this.reservedThread ){
@@ -334,7 +334,7 @@ $.oThread.prototype.wait = function( block_time ){
 /**
  * If started, will block until completion or timeout.
  */
-$.oThread.prototype.runSingleThreaded = function( ){
+exports.oThread.prototype.runSingleThreaded = function( ){
   this.started = true;
   for( var n=0;n<this.list.length;n++ ){
     this.kernel( 0, n, n+1 );
@@ -369,7 +369,7 @@ $.oThread.prototype.runSingleThreaded = function( ){
  * @property {string[]}  queryArgs    A string array of the different arguments given to the command.
  * @property {string}    log          The full log of all the messages outputted over the course of the process lifetime.
  */
-$.oProcess = function(bin, queryArgs){
+exports.oProcess = function(bin, queryArgs){
   this.readyRead = new this.$.oSignal()
   this.finished = new this.$.oSignal()
   this.bin = bin;
@@ -385,7 +385,7 @@ $.oProcess = function(bin, queryArgs){
  * @name $.oProcess#readChannel
  * @type {string}
  */
-Object.defineProperty($.oProcess.prototype, 'readChannel', {
+Object.defineProperty(exports.oProcess.prototype, 'readChannel', {
   get : function(){
     var merged = (this.process.processChannelMode() == QProcess.MergedChannels);
     if (merged) return "All";
@@ -411,7 +411,7 @@ Object.defineProperty($.oProcess.prototype, 'readChannel', {
 /**
  * kills the process instantly (useful for hanging processes, etc).
  */
-$.oProcess.prototype.kill = function(){
+exports.oProcess.prototype.kill = function(){
   if (!this.process) return;
   this.process.kill()
 }
@@ -419,7 +419,7 @@ $.oProcess.prototype.kill = function(){
 /**
  * Attempts to terminate the process execution by asking it to close itself.
  */
-$.oProcess.prototype.terminate = function(){
+exports.oProcess.prototype.terminate = function(){
   if (!this.process) return;
   this.process.terminate()
 }
@@ -507,7 +507,7 @@ $.oProcess.prototype.terminate = function(){
  * return readout
  *
  */
-$.oProcess.prototype.launchAndRead = function(readCallback, finishedCallback){
+exports.oProcess.prototype.launchAndRead = function(readCallback, finishedCallback){
   if (typeof timeOut === 'undefined') var timeOut = -1;
 
   var p = this.process;
@@ -547,7 +547,7 @@ $.oProcess.prototype.launchAndRead = function(readCallback, finishedCallback){
  * read the output of a process.
  * @return {string}   The lines as returned by the process since the last "read" instruction
  */
-$.oProcess.prototype.read = function (){
+exports.oProcess.prototype.read = function (){
   var p = this.process;
   if (p.readChannel == QProcess.StandardOutput){
     var readOut = p.readAllStandardOutput();
@@ -570,7 +570,7 @@ $.oProcess.prototype.read = function (){
  * Execute a process and waits for the end of the execution.
  * @return {string}   The lines as returned by the process.
  */
-$.oProcess.prototype.execute = function(){
+exports.oProcess.prototype.execute = function(){
   this.$.debug("Executing Process with arguments : "+this.bin+" "+this.queryArgs.join(" "), this.$.DEBUG_LEVEL.LOG);
 
   var p = this.process;
@@ -584,7 +584,7 @@ $.oProcess.prototype.execute = function(){
 /**
  * Execute a process as a separate application, which doesn't block the script execution and stops the script from interacting with it further.
  */
-$.oProcess.prototype.launchAndDetach = function(){
+exports.oProcess.prototype.launchAndDetach = function(){
   QProcess.startDetached(this.bin, this.queryArgs);
 }
 
@@ -610,7 +610,7 @@ $.oProcess.prototype.launchAndDetach = function(){
  * directly when the signal is emited, and the rest of the code will execute after.
  * @constructor
  */
-$.oSignal = function(type){
+exports.oSignal = function(type){
   // this.emitType = type;
   this.connexions = [];
   this.blocked = false;
@@ -622,7 +622,7 @@ $.oSignal = function(type){
  * @param {object} context
  * @param {function} slot
  */
-$.oSignal.prototype.connect = function (context, slot){
+exports.oSignal.prototype.connect = function (context, slot){
   // support slot.connect(callback) synthax
   if (typeof slot === 'undefined'){
     var slot = context;
@@ -636,7 +636,7 @@ $.oSignal.prototype.connect = function (context, slot){
  * Remove a connection registered with this Signal.
  * @param {function} [slot] the function to disconnect from the signal. If not specified, all connexions will be removed.
  */
-$.oSignal.prototype.disconnect = function(slot){
+exports.oSignal.prototype.disconnect = function(slot){
   if (typeof slot === "undefined"){
     this.connexions = [];
     return
@@ -653,7 +653,7 @@ $.oSignal.prototype.disconnect = function(slot){
 /**
  * Call the slot function using the provided context and and any arguments.
  */
-$.oSignal.prototype.emit = function () {
+exports.oSignal.prototype.emit = function () {
   if (this.blocked) return;
 
   // if (!(value instanceof this.type)){ // can't make it work for primitives, might try to fix later?
@@ -681,7 +681,7 @@ $.oSignal.prototype.emit = function () {
 }
 
 
-$.oSignal.prototype.toString = function(){
+exports.oSignal.prototype.toString = function(){
   return "Signal";
 }
 

--- a/openHarmony/openHarmony_timeline.js
+++ b/openHarmony/openHarmony_timeline.js
@@ -61,7 +61,7 @@
  * @property {oTimeline}               timeline              The timeline associated to this layer.
  * @property {oNode}                   node                  The node associated to the layer.
  */
-$.oLayer = function( oTimelineObject, layerIndex){
+exports.oLayer = function( oTimelineObject, layerIndex){
   this.timeline = oTimelineObject;
   this.index = layerIndex;
 }
@@ -72,7 +72,7 @@ $.oLayer = function( oTimelineObject, layerIndex){
  * @name $.oLayer#node
  * @type {$.oNode}
  */
-Object.defineProperty($.oLayer.prototype, "node", {
+Object.defineProperty(exports.oLayer.prototype, "node", {
   get: function(){
     if (this.$.batchMode){
       _node = this.timeline.nodes[this.index];
@@ -89,7 +89,7 @@ Object.defineProperty($.oLayer.prototype, "node", {
  * @name $.oLayer#parent
  * @type {$.oLayer}
  */
-Object.defineProperty($.oLayer.prototype, "parent", {
+Object.defineProperty(exports.oLayer.prototype, "parent", {
   get: function(){
     var _parentIndex = Timeline.parentNodeIndex(this.index);
     if (_parentIndex == -1) return $.scn.root;
@@ -106,7 +106,7 @@ Object.defineProperty($.oLayer.prototype, "parent", {
  * @type {bool}
  * @readonly
  */
- Object.defineProperty($.oLayer.prototype, "selected", {
+ Object.defineProperty(exports.oLayer.prototype, "selected", {
   get: function(){
     var selectionLength = Timeline.numLayerSel
     for (var i=0; i<selectionLength; i++){
@@ -126,7 +126,7 @@ Object.defineProperty($.oLayer.prototype, "parent", {
  * @type {string}
  * @readonly
  */
- Object.defineProperty($.oLayer.prototype, "name", {
+ Object.defineProperty(exports.oLayer.prototype, "name", {
   get: function(){
     return "unnamed layer";
   }
@@ -136,7 +136,7 @@ Object.defineProperty($.oLayer.prototype, "parent", {
 /**
  * @private
  */
-$.oLayer.prototype.toString = function(){
+exports.oLayer.prototype.toString = function(){
   return "<$.oLayer '"+this.name+"'>";
 }
 
@@ -164,10 +164,10 @@ $.oLayer.prototype.toString = function(){
  * @property {oTimeline}               timeline              The timeline associated to this layer.
  * @property {oNode}                   node                  The node associated to the layer.
  */
-$.oNodeLayer = function( oTimelineObject, layerIndex){
+exports.oNodeLayer = function( oTimelineObject, layerIndex){
   this.$.oLayer.apply(this, [oTimelineObject, layerIndex]);
 }
-$.oNodeLayer.prototype = Object.create($.oLayer.prototype);
+exports.oNodeLayer.prototype = Object.create(exports.oLayer.prototype);
 
 
 /**
@@ -175,7 +175,7 @@ $.oNodeLayer.prototype = Object.create($.oLayer.prototype);
  * @name $.oNodeLayer#name
  * @type {string}
  */
-Object.defineProperty($.oNodeLayer.prototype, "name", {
+Object.defineProperty(exports.oNodeLayer.prototype, "name", {
   get: function(){
     return this.node.name;
   },
@@ -190,7 +190,7 @@ Object.defineProperty($.oNodeLayer.prototype, "name", {
  * @name $.oNodeLayer#layerIndex
  * @type {int}
 */
-Object.defineProperty($.oNodeLayer.prototype, "layerIndex", {
+Object.defineProperty(exports.oNodeLayer.prototype, "layerIndex", {
   get: function(){
     var _layers = this.timeline.layers.map(function(x){return x.node.path});
     return _layers.indexOf(this.node.path);
@@ -203,7 +203,7 @@ Object.defineProperty($.oNodeLayer.prototype, "layerIndex", {
  * @name $.oNodeLayer#selected
  * @type {bool}
  */
-Object.defineProperty($.oNodeLayer.prototype, "selected", {
+Object.defineProperty(exports.oNodeLayer.prototype, "selected", {
   get: function(){
     if ($.batchMode) return this.node.selected;
 
@@ -224,7 +224,7 @@ Object.defineProperty($.oNodeLayer.prototype, "selected", {
  * @name $.oNodeLayer#subLayers
  * @type {$.oColumnLayer[]}
 */
-Object.defineProperty($.oNodeLayer.prototype, "subLayers", {
+Object.defineProperty(exports.oNodeLayer.prototype, "subLayers", {
   get: function(){
     var _node = this.node;
     var _nodeLayerType = this.$.oNodeLayer;
@@ -237,7 +237,7 @@ Object.defineProperty($.oNodeLayer.prototype, "subLayers", {
 /**
  * @private
  */
-$.oNodeLayer.prototype.toString = function(){
+exports.oNodeLayer.prototype.toString = function(){
   return "<$.oNodeLayer '"+this.name+"'>";
 }
 
@@ -265,10 +265,10 @@ $.oNodeLayer.prototype.toString = function(){
  * @property {oTimeline}               timeline              The timeline associated to this layer.
  * @property {oNode}                   node                  The node associated to the layer.
  */
-$.oDrawingLayer = function( oTimelineObject, layerIndex){
+exports.oDrawingLayer = function( oTimelineObject, layerIndex){
   this.$.oNodeLayer.apply(this, [oTimelineObject, layerIndex]);
 }
-$.oDrawingLayer.prototype = Object.create($.oNodeLayer.prototype);
+exports.oDrawingLayer.prototype = Object.create(exports.oNodeLayer.prototype);
 
 
 /**
@@ -276,7 +276,7 @@ $.oDrawingLayer.prototype = Object.create($.oNodeLayer.prototype);
  * @name oDrawingLayer#drawingColumn
  * @type {oFrame[]}
  */
- Object.defineProperty($.oDrawingLayer.prototype, "drawingColumn", {
+ Object.defineProperty(exports.oDrawingLayer.prototype, "drawingColumn", {
   get: function(){
     return this.node.attributes.drawing.elements.column;
   }
@@ -288,7 +288,7 @@ $.oDrawingLayer.prototype = Object.create($.oNodeLayer.prototype);
  * @name oDrawingLayer#exposures
  * @type {oFrame[]}
  */
-Object.defineProperty($.oDrawingLayer.prototype, "exposures", {
+Object.defineProperty(exports.oDrawingLayer.prototype, "exposures", {
   get: function(){
     return this.drawingColumn.frames;
   }
@@ -298,7 +298,7 @@ Object.defineProperty($.oDrawingLayer.prototype, "exposures", {
 /**
  * @private
  */
- $.oDrawingLayer.prototype.toString = function(){
+ exports.oDrawingLayer.prototype.toString = function(){
   return "<$.oDrawingLayer '"+this.name+"'>";
 }
 
@@ -325,10 +325,10 @@ Object.defineProperty($.oDrawingLayer.prototype, "exposures", {
  * @property {oTimeline}               timeline              The timeline associated to this layer.
  * @property {oNode}                   node                  The node associated to the layer.
  */
-$.oColumnLayer = function( oTimelineObject, layerIndex){
+exports.oColumnLayer = function( oTimelineObject, layerIndex){
   this.$.oLayer.apply(this, [oTimelineObject, layerIndex]);
 }
-$.oColumnLayer.prototype = Object.create($.oLayer.prototype);
+exports.oColumnLayer.prototype = Object.create(exports.oLayer.prototype);
 
 
 /**
@@ -337,7 +337,7 @@ $.oColumnLayer.prototype = Object.create($.oLayer.prototype);
  * @name $.oColumnLayer#name
  * @type {string}
  */
-Object.defineProperty($.oColumnLayer.prototype, "name", {
+Object.defineProperty(exports.oColumnLayer.prototype, "name", {
   get: function(){
     return this.column.name;
   }
@@ -350,7 +350,7 @@ Object.defineProperty($.oColumnLayer.prototype, "name", {
  * @name $.oColumnLayer#attribute
  * @type {$.oColumn}
  */
-Object.defineProperty($.oColumnLayer.prototype, "attribute", {
+Object.defineProperty(exports.oColumnLayer.prototype, "attribute", {
   get: function(){
     if (!this._attribute){
       this._attribute = this.column.attributeObject;
@@ -366,7 +366,7 @@ Object.defineProperty($.oColumnLayer.prototype, "attribute", {
  * @name $.oColumnLayer#column
  * @type {$.oColumn}
  */
-Object.defineProperty($.oColumnLayer.prototype, "column", {
+Object.defineProperty(exports.oColumnLayer.prototype, "column", {
   get: function(){
     if (!this._column){
       var _name = Timeline.layerToColumn(this.index);
@@ -381,7 +381,7 @@ Object.defineProperty($.oColumnLayer.prototype, "column", {
 /**
  * The layer representing the node to which this column is linked
  */
-Object.defineProperty($.oColumnLayer.prototype, "nodeLayer", {
+Object.defineProperty(exports.oColumnLayer.prototype, "nodeLayer", {
   get: function(){
     var _node = this.node;
     var _nodeLayerType = this.$.oNodeLayer;
@@ -394,7 +394,7 @@ Object.defineProperty($.oColumnLayer.prototype, "nodeLayer", {
 /**
  * @private
  */
- $.oColumnLayer.prototype.toString = function(){
+ exports.oColumnLayer.prototype.toString = function(){
   return "<$.oColumnLayer '"+this.name+"'>";
 }
 
@@ -419,7 +419,7 @@ Object.defineProperty($.oColumnLayer.prototype, "nodeLayer", {
  *
  * @property {string}     display    The display node's path.
  */
-$.oTimeline = function(display){
+exports.oTimeline = function(display){
   if (typeof display === 'undefined') var display = this.$.scn.defaultDisplay;
   if (display instanceof this.$.oNode) display = display.path;
 
@@ -432,7 +432,7 @@ $.oTimeline = function(display){
  * @name $.oTimeline#layers
  * @type {$.oLayer[]}
  */
-Object.defineProperty($.oTimeline.prototype, 'layers', {
+Object.defineProperty(exports.oTimeline.prototype, 'layers', {
   get : function(){
     var nodeLayer = this.$.oNodeLayer;
     return this.allLayers.filter(function (x){return x instanceof nodeLayer})
@@ -445,7 +445,7 @@ Object.defineProperty($.oTimeline.prototype, 'layers', {
  * @name $.oTimeline#allLayers
  * @type {$.oLayer[]}
  */
-Object.defineProperty($.oTimeline.prototype, 'allLayers', {
+Object.defineProperty(exports.oTimeline.prototype, 'allLayers', {
   get : function(){
     if (!this._layers){
       var _layers = [];
@@ -482,7 +482,7 @@ Object.defineProperty($.oTimeline.prototype, 'allLayers', {
  * @name $.oTimeline#selectedLayers
  * @type {oTimelineLayer[]}
  */
-Object.defineProperty($.oTimeline.prototype, 'selectedLayers', {
+Object.defineProperty(exports.oTimeline.prototype, 'selectedLayers', {
   get : function(){
     return this.allLayers.filter(function(x){return x.selected});
   }
@@ -497,7 +497,7 @@ Object.defineProperty($.oTimeline.prototype, 'selectedLayers', {
  * @type {oNode[]}
  * @deprecated use oTimeline.nodes instead if you want the nodes
  */
-Object.defineProperty($.oTimeline.prototype, 'compositionLayers', {
+Object.defineProperty(exports.oTimeline.prototype, 'compositionLayers', {
   get : function(){
     return this.nodes;
   }
@@ -509,7 +509,7 @@ Object.defineProperty($.oTimeline.prototype, 'compositionLayers', {
  * @name $.oTimeline#nodes
  * @type {oNode[]}
  */
-Object.defineProperty($.oTimeline.prototype, 'nodes', {
+Object.defineProperty(exports.oTimeline.prototype, 'nodes', {
   get : function(){
     var _timeline = this.compositionLayersList;
     var _scene = this.$.scene;
@@ -527,7 +527,7 @@ Object.defineProperty($.oTimeline.prototype, 'nodes', {
  * @type {string[]}
  * @deprecated only returns node path strings, use oTimeline.layers insteads
  */
-Object.defineProperty($.oTimeline.prototype, 'nodesList', {
+Object.defineProperty(exports.oTimeline.prototype, 'nodesList', {
   get : function(){
     return this.compositionLayersList;
   }
@@ -540,7 +540,7 @@ Object.defineProperty($.oTimeline.prototype, 'nodesList', {
  * @type {string[]}
  * @deprecated only returns node path strings
  */
-Object.defineProperty($.oTimeline.prototype, 'compositionLayersList', {
+Object.defineProperty(exports.oTimeline.prototype, 'compositionLayersList', {
   get : function(){
     var _composition = this.composition;
     var _timeline = _composition.map(function(x){return x.node})
@@ -554,7 +554,7 @@ Object.defineProperty($.oTimeline.prototype, 'compositionLayersList', {
  * gets the composition for this timeline (array of native toonboom api 'compositionItems' objects)
  * @deprecated exposes native harmony api objects
  */
-Object.defineProperty($.oTimeline.prototype, "composition", {
+Object.defineProperty(exports.oTimeline.prototype, "composition", {
   get: function(){
     return compositionOrder.buildCompositionOrderForDisplay(this.display);
   }
@@ -566,7 +566,7 @@ Object.defineProperty($.oTimeline.prototype, "composition", {
  * Refreshes the oTimeline's cached listing- in the event it changes in the runtime of the script.
  * @deprecated oTimeline.composition is now always refreshed when accessed.
  */
-$.oTimeline.prototype.refresh = function( ){
+exports.oTimeline.prototype.refresh = function( ){
   if (!node.type(this.display)) {
       this.composition = compositionOrder.buildDefaultCompositionOrder();
   }else{
@@ -579,7 +579,7 @@ $.oTimeline.prototype.refresh = function( ){
  * Build column to oNode/Attribute lookup cache. Makes the layer generation faster if using oTimeline.layers, oTimeline.selectedLayers
  * @deprecated
  */
-$.oTimeline.prototype.buildLayerCache = function( forced ){
+exports.oTimeline.prototype.buildLayerCache = function( forced ){
   if (typeof forced === 'undefined') forced = false;
 
   var cdate   = (new Date).getTime();

--- a/openHarmony/openHarmony_tool.js
+++ b/openHarmony/openHarmony_tool.js
@@ -79,7 +79,7 @@
  *
  * brushTool.activate()           // by using the activate function of the oTool class
  */
-$.oTool = function(id, name){
+exports.oTool = function(id, name){
   this.id = id;
   this.name = name;
 }
@@ -90,7 +90,7 @@ $.oTool = function(id, name){
  * @name $.oTool#stencils
  * @type {$.oStencil[]}
  */
-Object.defineProperty($.oTool, "stencils", {
+Object.defineProperty(exports.oTool, "stencils", {
   get: function(){
     // an object describing what tool can use what stencils
     var _stencilTypes = {
@@ -121,11 +121,11 @@ Object.defineProperty($.oTool, "stencils", {
 /**
  * Activates the tool.
  */
-$.oTool.prototype.activate = function(){
+exports.oTool.prototype.activate = function(){
   Tools.setToolSettings({currentTool:{id:this.id}});
 }
 
 
-$.oTool.prototype.toString = function(){
+exports.oTool.prototype.toString = function(){
   return "< oTool '"+ this.name + "'>"
 }

--- a/openHarmony/openHarmony_tool.js
+++ b/openHarmony/openHarmony_tool.js
@@ -65,7 +65,7 @@
  *
  * // output the list of tools names and ids
  * for (var i in tools){
- *   log(i+" "+tools[i].name)
+ *   $.log(i+" "+tools[i].name)
  * }
  *
  * // To get a tool by name, use the $.app.getToolByName() function


### PR DESCRIPTION
Restructured slightly so that openHarmony is used by calling `const $ = require("openHarmony.js")` instead of `include`. Each sub-script adds its functions to the `exports` object, which the main script `require()`s, and then adds the attributes of to `$`.

It seems like using `include` may still work, although I haven't tested this thouroughly yet.

In the current state, it can run the example script and make a car, although there are several errors with cloning nodes (`TypeError: ambiguous call of overloaded function setValue()`, in ...attribute.js ln695), and with linking nodes that don't seem to impact the car.

TO DO:
- API functions aren't accessible globally, which they were before (usually). I tried using `this.__proto__[classItem] = $[classItem]` which I *thought* would add them to the prototype of the global scope, like the regular API functions, but they ended up as members of the top-level `this`, so I obviously don't understand what's going on.
- I haven't thoroughly checked the built in documentation, and I haven't checked peripheral files outside `./openHarmony/*`, `./openHarmony.js`, and `./examples/openHarmonyExample.js`
- installers still create stubs that use `inlcude`. I have a funny setup locally, so I haven't gotten around to looking at these yet
- Testing
  - Some kind of test structure or external package? I am happy to write tests, but probably need examples to follow. I tried writing a simple one as a learning exercise, but it wasn't very good.