### PR TITLE
add 'DEBUG' to $.DEBUG_LEVELS

### DIFF
--- a/openHarmony/base.js
+++ b/openHarmony/base.js
@@ -104,7 +104,8 @@ $.getScene = $.s;
 $.DEBUG_LEVEL = {
   'ERROR'   : 0,
   'WARNING' : 1,
-  'LOG'     : 2
+  'LOG'     : 2,
+  'DEBUG'   : 3
 }
 
 /**


### PR DESCRIPTION
not having 'DEBUG' defined was resulting in debug level logs always being printed. `undefined > number` returns false, so the short-circuit return in $.debug wasn't firing