### PR TITLE
Feature: paste frames from template

### DIFF
--- a/openHarmony/classes/oNode.js
+++ b/openHarmony/classes/oNode.js
@@ -2890,18 +2890,33 @@ oGroupNode.prototype.addGroup = function( name, addComposite, addPeg, includeNod
 /**
  * Imports the specified template into the scene.
  * @param   {string}           tplPath                                        The path of the TPL file to import.
- * @param   {$.oNode[]}        [destinationNodes=false]                       The nodes affected by the template.
+ * @param   {$.oNode[]}        [destinationNodes=false]                       The nodes affected by the template. When set, delegates to pasteFramesFromTemplate. Use pasteFramesFromTemplate directly for better animation keyframe support.
  * @param   {bool}             [extendScene=true]                             Whether to extend the exposures of the content imported.
  * @param   {$.oPoint}         [nodePosition={0,0,0}]                         The position to offset imported new nodes.
  * @param   {object}           [pasteOptions]                                 An object containing paste options as per Harmony's standard paste options.
  *
- * @return {$.oNode[]}         The resulting pasted nodes.
+ * @return {$.oNode[]|false}   The resulting pasted nodes, or false if the import failed.
  */
 oGroupNode.prototype.importTemplate = function( tplPath, destinationNodes, extendScene, nodePosition, pasteOptions ){
   if (typeof nodePosition === 'undefined') var nodePosition = new this.$.oPoint(0,0,0);
   if (typeof destinationNodes === 'undefined' || destinationNodes.length == 0) var destinationNodes = false;
   if (typeof extendScene === 'undefined') var extendScene = true;
 
+  // When destinationNodes is set, delegate to pasteFramesFromTemplate
+  if (destinationNodes){
+    this.$.log("oGroupNode.importTemplate with destinationNodes is deprecated. Use oGroupNode.pasteFramesFromTemplate instead for better animation keyframe support.");
+    
+    // Use pasteFramesFromTemplate with default parameters (whole template, frame 1, match by name)
+    var success = this.pasteFramesFromTemplate(tplPath, destinationNodes, 1, undefined, true);
+    
+    if (success) {
+      return destinationNodes;
+    } else {
+      return false;
+    }
+  }
+
+  // Original logic for creating new nodes
   if (typeof pasteOptions === 'undefined') var pasteOptions = copyPaste.getCurrentPasteOptions();
   pasteOptions.extendScene = extendScene;
 
@@ -2914,54 +2929,120 @@ oGroupNode.prototype.importTemplate = function( tplPath, destinationNodes, exten
   this.$.debug("importing template : "+tplPath, this.$.DEBUG_LEVEL.LOG);
 
   var _copyOptions = copyPaste.getCurrentCreateOptions();
-  var _tpl = copyPaste.copyFromTemplate(tplPath, 0, 999, _copyOptions); // any way to get the length of a template before importing it?
+  var _tpl = copyPaste.copyFromTemplate(tplPath, 0, 0, _copyOptions);
 
-  if (destinationNodes){
-    // TODO: deal with import options to specify frames
-    copyPaste.paste(_tpl, destinationNodes.map(function(x){return x.path}), 0, 999, pasteOptions);
-    var _nodes = destinationNodes;
-  }else{
-    var oldBackdrops = this.backdrops;
-    copyPaste.pasteNewNodes(_tpl, _group, pasteOptions);
-    var _scene = this.scene;
-    var _nodes = selection.selectedNodes().map(function(x){return _scene.$node(x)});
-    for (var i in _nodes){
-      // only move the root nodes
-      if (_nodes[i].parent.path != this.path) continue
+  if (_tpl == null) {
+    this.$.debug("Error: Unable to read/parse template: " + tplPath, this.$.DEBUG_LEVEL.ERROR);
+    this.$.endUndo();
+    return false;
+  }
 
-      _nodes[i].x += nodePosition.x;
-      _nodes[i].y += nodePosition.y;
-    }
+  var oldBackdrops = this.backdrops;
+  copyPaste.pasteNewNodes(_tpl, _group, pasteOptions);
+  var _scene = this.scene;
+  var _nodes = selection.selectedNodes().map(function(x){return _scene.$node(x)});
+  for (var i in _nodes){
+    // only move the root nodes
+    if (_nodes[i].parent.path != this.path) continue
 
-    // move backdrops present in the template
-    var allBackdrops = this.backdrops;
-    var newBackdrops = allBackdrops.slice(0,allBackdrops.length - oldBackdrops.length);
-    for (var i in newBackdrops){
-      newBackdrops[i].x += nodePosition.x;
-      newBackdrops[i].y += nodePosition.y;
-    }
+    _nodes[i].x += nodePosition.x;
+    _nodes[i].y += nodePosition.y;
+  }
 
-    // move waypoints in the top level of the template
-    for (var i in _nodes) {
-      var nodePorts = _nodes[i].outPorts;
-      for (var p = 0; p < nodePorts; p++) {
-        var theseWP = waypoint.childWaypoints(_nodes[i], p);
-        if (theseWP.length > 0) {
-          for (var w in theseWP) {
-            var x = waypoint.coordX(theseWP[w]);
-            var y = waypoint.coordY(theseWP[w]);
-            x += nodePosition.x;
-            y += nodePosition.y;
-            waypoint.setCoord(theseWP[w],x,y);
-          }
+  // move backdrops present in the template
+  var allBackdrops = this.backdrops;
+  var newBackdrops = allBackdrops.slice(0,allBackdrops.length - oldBackdrops.length);
+  for (var i in newBackdrops){
+    newBackdrops[i].x += nodePosition.x;
+    newBackdrops[i].y += nodePosition.y;
+  }
+
+  // move waypoints in the top level of the template
+  for (var i in _nodes) {
+    var nodePorts = _nodes[i].outPorts;
+    for (var p = 0; p < nodePorts; p++) {
+      var theseWP = waypoint.childWaypoints(_nodes[i], p);
+      if (theseWP.length > 0) {
+        for (var w in theseWP) {
+          var x = waypoint.coordX(theseWP[w]);
+          var y = waypoint.coordY(theseWP[w]);
+          x += nodePosition.x;
+          y += nodePosition.y;
+          waypoint.setCoord(theseWP[w],x,y);
         }
       }
     }
-
   }
 
   this.$.endUndo();
   return _nodes;
+}
+
+
+/**
+ * Pastes frames from template to destination nodes with animation keyframe copying support.
+ * @param   {string}           tplPath                                        The path of the TPL file to import.
+ * @param   {$.oNode[]}        destinationNodes                                Nodes to paste to.
+ * @param   {int}              [startFrame=1]                                  Destination frame to paste at.
+ * @param   {int[]}            [srcFrameRange]                                 Source frame range [startFrame, endFrame] from template. If not specified, imports whole template.
+ * @param   {bool}             [matchNodesByName=true]                         Whether to match nodes by name during paste.
+ * @return {bool}              True if paste succeeded, false otherwise.
+ */
+oGroupNode.prototype.pasteFramesFromTemplate = function( tplPath, destinationNodes, startFrame, srcFrameRange, matchNodesByName ){
+  if (typeof destinationNodes === 'undefined' || destinationNodes.length == 0) {
+    this.$.debug("Error: destinationNodes must be specified.", this.$.DEBUG_LEVEL.ERROR);
+    return false;
+  }
+
+  this.$.beginUndo("oH_pasteFramesFromTemplate");
+
+  if(tplPath instanceof this.$.oFolder) tplPath = tplPath.path;
+
+  this.$.debug("pasting frames from template : "+tplPath, this.$.DEBUG_LEVEL.LOG);
+
+  // Configure paste special for keyframe copying
+  // copyPaste.usePasteSpecial(true);
+  // copyPaste.setPasteSpecialForcesKeyFrameAtBegAndEnd(true);
+  if (typeof matchNodesByName === 'undefined' || matchNodesByName) {
+    copyPaste.setPasteSpecialMatchNodeName(true);
+  }
+  // var backupPasteLocalValue = copyPaste.getCurrentPasteOptions().fullTransfer;
+  // copyPaste.setPasteSpecialFullTransfer(true);
+
+  var pasteOptions = copyPaste.getCurrentPasteOptions();
+  pasteOptions.actionTemplateMode = false; // Critical: false enables proper animation key copying
+
+  var _copyOptions = copyPaste.getCurrentCreateOptions();
+  var _srcStartFrame = 0;
+  var _numFrames = 0;
+  if (typeof srcFrameRange !== 'undefined' && Array.isArray(srcFrameRange) && srcFrameRange.length === 2) {
+    if (srcFrameRange[0] > 0 && srcFrameRange[1] >= srcFrameRange[0]) {
+      _srcStartFrame = srcFrameRange[0];
+      _numFrames = srcFrameRange[1] - srcFrameRange[0] + 1;
+    }
+  }
+  var _destStartFrame = (typeof startFrame !== 'undefined' && startFrame > 0) ? startFrame : 1;
+
+  var _tpl = copyPaste.copyFromTemplate(tplPath, _srcStartFrame, _numFrames, _copyOptions);
+
+  if (_tpl == null) {
+    this.$.debug("Error: Unable to read/parse template: " + tplPath, this.$.DEBUG_LEVEL.ERROR);
+    // copyPaste.setPasteSpecialFullTransfer(backupPasteLocalValue);
+    this.$.endUndo();
+    return false;
+  }
+
+  var match = copyPaste.paste(_tpl, destinationNodes.map(function(x){return x.path}), _destStartFrame, _numFrames, pasteOptions);
+  if (match == false) {
+    this.$.debug("Error: Structure of destination does not match the structure of the template.", this.$.DEBUG_LEVEL.ERROR);
+    // copyPaste.setPasteSpecialFullTransfer(backupPasteLocalValue);
+    this.$.endUndo();
+    return false;
+  }
+
+  //copyPaste.setPasteSpecialFullTransfer(backupPasteLocalValue);
+  this.$.endUndo();
+  return true;
 }
 
 


### PR DESCRIPTION
Same code as #76 after discussion but rebased on refactor branch.

## Summary
Adds a dedicated method for pasting animation keyframes from templates to existing nodes with proper frame range support and improved error handling.
*NB: I've kept commented the setPasteSpecial* functions for you to test if it works without them on your side, because removing them changed nothing for me...

## Changes
- **New method**: `oGroupNode.pasteFramesFromTemplate()` - Dedicated function for pasting frames from templates to destination nodes
- **Refactored**: `oGroupNode.importTemplate()` now delegates to `pasteFramesFromTemplate` when `destinationNodes` is provided (with deprecation warning)
- **Improved**: Better error handling with null checks and proper return values
- **Fixed**: Template frame range handling (changed from hardcoded `0, 999` to `0, 0` for whole template)

## Key Features
- Proper animation keyframe copying support via `actionTemplateMode: false`
- Optional source frame range selection (`srcFrameRange`)
- Configurable destination start frame (`startFrame`)
- Node matching by name (configurable via `matchNodesByName`)

## Usage
```js
// Paste entire template to nodes starting at frame 1
group.pasteFramesFromTemplate(tplPath, destinationNodes);

// Paste specific frame range to custom start frame
group.pasteFramesFromTemplate(tplPath, destinationNodes, 10, [5, 20]);

// Disable node name matching
group.pasteFramesFromTemplate(tplPath, destinationNodes, 1, undefined, false);
```

## Backward Compatibility
`importTemplate()` with `destinationNodes` still works but logs a deprecation warning and delegates to the new method.