### PR TITLE
Feature: oNode get-set attributes snapshot

### DIFF
--- a/openHarmony/classes/oNode.js
+++ b/openHarmony/classes/oNode.js
@@ -1640,26 +1640,38 @@ oNode.prototype.getAttributeSnapshot = function() {
   var snapshot = {};
 
   function captureAttr(attr) {
-    // Capture drawing substitutions.
+    // --- Drawing substitution column: record each distinct drawing name change ---
     if (attr.type === "ELEMENT") {
       var elementCol = attr.column;
       if (elementCol) {
-        var elementKeys = elementCol.keyframes;
+        var colName = elementCol.uniqueName;
+        var sceneLen = $.scene.length;
         var elementData = [];
-        for (var eki = 0; eki < elementKeys.length; eki++) {
-          elementData.push({ f: elementKeys[eki].frameNumber, v: elementKeys[eki].value });
+        var prev = null;
+        // Walk every frame; store only frames where the drawing name changes.
+        for (var frame = 1; frame <= sceneLen; frame++) {
+          var drawingName = column.getEntry(colName, 1, frame);
+          if (!drawingName) continue;
+          if (drawingName !== prev) {
+            elementData.push({ f: frame, v: drawingName });
+            prev = drawingName;
+          }
         }
-        if (elementData.length > 0) snapshot[attr.keyword] = { __anim: true, keys: elementData, colType: elementCol.type };
+        if (elementData.length > 0) {
+          snapshot[attr.keyword] = { __anim: true, keys: elementData, colType: "DRAWING" };
+        }
       }
       return;
     }
 
+    // --- Compound attribute: recurse into sub-attributes ---
     var subs = attr.subAttributes;
     if (subs && subs.length > 0) {
       for (var i = 0; i < subs.length; i++) captureAttr(subs[i]);
       return;
     }
 
+    // --- Animated column: store each keyframe value ---
     var col = attr.column;
     if (col) {
       // Expression columns are driven by the template; don't capture them.
@@ -1667,12 +1679,13 @@ oNode.prototype.getAttributeSnapshot = function() {
       var keys = col.keyframes;
       if (keys && keys.length > 0) {
         var keyData = [];
-        for (var ki = 0; ki < keys.length; ki++) {
-          var v = keys[ki].value;
-          if (v !== null && typeof v === 'object' && typeof v.x === 'number') {
-            v = { x: v.x, y: v.y, z: (typeof v.z === 'number') ? v.z : 0 };
+        for (var keyIndex = 0; keyIndex < keys.length; keyIndex++) {
+          var keyValue = keys[keyIndex].value;
+          // Normalise vector values to a plain {x,y,z} object.
+          if (keyValue !== null && typeof keyValue === 'object' && typeof keyValue.x === 'number') {
+            keyValue = { x: keyValue.x, y: keyValue.y, z: (typeof keyValue.z === 'number') ? keyValue.z : 0 };
           }
-          keyData.push({ f: keys[ki].frameNumber, v: v });
+          keyData.push({ f: keys[keyIndex].frameNumber, v: keyValue });
         }
         if (keyData.length > 0) {
           snapshot[attr.keyword] = { __anim: true, keys: keyData, colType: col.type };
@@ -1681,11 +1694,13 @@ oNode.prototype.getAttributeSnapshot = function() {
       }
     }
 
+    // --- Static value: store as-is, skip XML-blob strings ---
     var val = attr.getValue();
     if (typeof val === 'string' && val.charAt(0) === '<') return;
     snapshot[attr.keyword] = val;
   }
 
+  // Capture every attribute on this node.
   var attrs = this.attributes;
   for (var key in attrs) {
     try { captureAttr(attrs[key]); } catch (e) {}
@@ -1718,8 +1733,48 @@ oNode.prototype.applyAttributeSnapshot = function(snapshot) {
 
       if (snapVal && typeof snapVal === 'object' && snapVal.__anim === true) {
         var keys = snapVal.keys;
-        for (var ki = 0; ki < keys.length; ki++) {
-          attr.setValue(keys[ki].v, keys[ki].f);
+        if (attr.type === "ELEMENT") {
+          // Drawing exposure: explicitly fill every frame across the whole scene.
+          var colName = col.uniqueName;
+          var sceneLen = $.scene.length;
+          var snapshotKeyIndex = 0;
+          var setEntryFailed = false;
+
+          // If the pasted frame-1 value differs from the snapshot, process frames
+          // 2+ first so frame-1 is not overwritten while later frames are still
+          // "held" from it.
+          var frame1KeyIndex = 0;
+          while (frame1KeyIndex + 1 < keys.length && keys[frame1KeyIndex + 1].f <= 1) frame1KeyIndex++;
+          var frame1Desired = keys[frame1KeyIndex].v;
+          var deferFrame1 = column.getEntry(colName, 1, 1) !== frame1Desired;
+          var frameFillOrder = [];
+          for (var fillFrame = (deferFrame1 ? 2 : 1); fillFrame <= sceneLen; fillFrame++) frameFillOrder.push(fillFrame);
+          if (deferFrame1) frameFillOrder.push(1); // frame 1 processed last
+
+          for (var fillIndex = 0; fillIndex < frameFillOrder.length; fillIndex++) {
+            var targetFrame = frameFillOrder[fillIndex];
+            // Advance key pointer to the last snapshot key whose frame <= targetFrame.
+            while (snapshotKeyIndex + 1 < keys.length && keys[snapshotKeyIndex + 1].f <= targetFrame) snapshotKeyIndex++;
+            // When retrying frame 1 (processed last), reset to attempt column.setEntry
+            // again — the column is no longer freshly-pasted at this point.
+            if (deferFrame1 && targetFrame === 1) setEntryFailed = false;
+            var desiredDrawing = keys[snapshotKeyIndex].v;
+            if (column.getEntry(colName, 1, targetFrame) === desiredDrawing) continue;
+            if (!setEntryFailed) {
+              try {
+                column.setEntry(colName, 1, targetFrame, desiredDrawing);
+                continue;
+              } catch (_fe) {
+                setEntryFailed = true;
+              }
+            }
+            node.setTextAttr(this.path, "drawing.element", targetFrame, desiredDrawing);
+          }
+        } else {
+          // --- Animated non-drawing column: restore each captured keyframe ---
+          for (var keyIndex = 0; keyIndex < keys.length; keyIndex++) {
+            attr.setValue(keys[keyIndex].v, keys[keyIndex].f);
+          }
         }
       } else {
         attr.setValue(snapVal);

--- a/openHarmony/classes/oNode.js
+++ b/openHarmony/classes/oNode.js
@@ -1697,30 +1697,38 @@ oNode.prototype.getAttributeSnapshot = function() {
 
 /**
  * Apply a snapshot produced by getAttributeSnapshot() to this node's attributes.
+ * Each attribute is applied independently; failures log a message.
  * @param  {object}  snapshot  Object from getAttributeSnapshot().
  * @return {oNode}   this, for chaining.
  */
 oNode.prototype.applyAttributeSnapshot = function(snapshot) {
   for (var keyword in snapshot) {
-    var attr = this.getAttributeByName(keyword);
-    if (!attr) continue;
+    try {
+      var attr = this.getAttributeByName(keyword);
+      if (!attr) continue;
 
-    var snapVal = snapshot[keyword];
-    var col = attr.column;
+      var snapVal = snapshot[keyword];
+      var col = attr.column;
 
-    if (attr.type === "ELEMENT") {
-      if (!col) continue;  // no drawing column on the new node, skip
-    } else {
-      if (col && col.type === "EXPR") continue;  // expression-driven, skip
-    }
-
-    if (snapVal && typeof snapVal === 'object' && snapVal.__anim === true) {
-      var keys = snapVal.keys;
-      for (var ki = 0; ki < keys.length; ki++) {
-        attr.setValue(keys[ki].v, keys[ki].f);
+      if (attr.type === "ELEMENT") {
+        if (!col) continue;  // no drawing column on the new node, skip
+      } else {
+        if (col && col.type === "EXPR") continue;  // expression-driven, skip
       }
-    } else {
-      attr.setValue(snapVal);
+
+      if (snapVal && typeof snapVal === 'object' && snapVal.__anim === true) {
+        var keys = snapVal.keys;
+        for (var ki = 0; ki < keys.length; ki++) {
+          attr.setValue(keys[ki].v, keys[ki].f);
+        }
+      } else {
+        attr.setValue(snapVal);
+      }
+    } catch (err) {
+      this.$.log(
+        'oNode.applyAttributeSnapshot: skipped attribute "' + keyword +
+        '" on ' + this.path + " — " + String(err)
+      );
     }
   }
 

--- a/openHarmony/classes/oNode.js
+++ b/openHarmony/classes/oNode.js
@@ -1683,14 +1683,23 @@ oNode.prototype.getAttributeSnapshot = function() {
         var prev = null;
         for (var frame = 1; frame <= sceneLen; frame++) {
           var drawingName = column.getEntry(elementColName, 1, frame);
-          if (!drawingName) continue;
-          if (drawingName !== prev) {
+          // Blanks ("") are intentional exposure gaps
+          if (drawingName === null || drawingName === undefined) drawingName = "";
+          if (prev === null || drawingName !== prev) {
             elementData.push({ f: frame, v: drawingName });
             prev = drawingName;
           }
         }
+        // Record the column's display name.
+        var capturedColumnDisplay = null;
+        try { capturedColumnDisplay = column.getDisplayName(elementColName); } catch (_dn) {}
         if (elementData.length > 0) {
-          snapshot[attr.keyword] = { __anim: true, keys: elementData, colType: "DRAWING" };
+          snapshot[attr.keyword] = {
+            __anim: true,
+            keys: elementData,
+            colType: "DRAWING",
+            columnDisplay: capturedColumnDisplay
+          };
         }
       }
       return;
@@ -1838,6 +1847,16 @@ oNode.prototype.applyAttributeSnapshot = function(snapshot) {
       if (attr.type === "ELEMENT") {
         // Drawing exposure: explicitly fill every frame across the whole scene.
         var elementColName = col.uniqueName;
+
+        // Drawing columns are often shared across several nodes.
+        if (snapVal.columnDisplay !== undefined && snapVal.columnDisplay !== null) {
+          var newColumnDisplay = null;
+          try { newColumnDisplay = column.getDisplayName(elementColName); } catch (_dn) {}
+          if (newColumnDisplay !== snapVal.columnDisplay) {
+            continue;
+          }
+        }
+
         var sceneLen = $.scene.length;
         var elementKeyIndex = 0;
         var setEntryFailed = false;

--- a/openHarmony/classes/oNode.js
+++ b/openHarmony/classes/oNode.js
@@ -1771,7 +1771,21 @@ oNode.prototype.applyAttributeSnapshot = function(snapshot) {
             node.setTextAttr(this.path, "drawing.element", targetFrame, desiredDrawing);
           }
         } else {
-          // --- Animated non-drawing column: restore each captured keyframe ---
+          // --- Animated non-drawing column.
+          // Step 1: Delete every template keyframe that's not in our snapshot, so the
+          // column ends up with exactly the keyframes from the original container.
+          // Step 2: Apply our snapshot keys, restoring exactly what was on the old node.
+          var templateKeys = col ? col.keyframes : [];
+          var colName = col ? col.uniqueName : null;
+          var snapFrameSet = {};
+          for (var sk = 0; sk < keys.length; sk++) snapFrameSet[keys[sk].f] = true;
+          if (colName) {
+            for (var tk = 0; tk < templateKeys.length; tk++) {
+              var tf = templateKeys[tk].frameNumber;
+              if (snapFrameSet[tf]) continue;
+              try { column.clearKeyFrame(colName, tf); } catch (_ce) {}
+            }
+          }
           for (var keyIndex = 0; keyIndex < keys.length; keyIndex++) {
             attr.setValue(keys[keyIndex].v, keys[keyIndex].f);
           }

--- a/openHarmony/classes/oNode.js
+++ b/openHarmony/classes/oNode.js
@@ -1631,6 +1631,103 @@ oNode.prototype.clone = function( newName, newPosition ){
 };
 
 
+/**
+ * Capture a snapshot of this node's attribute values, including animation
+ * keyframes and drawing substitutions. Pair with applyAttributeSnapshot().
+ * @return {object}  Plain object mapping attribute keywords to captured values.
+ */
+oNode.prototype.getAttributeSnapshot = function() {
+  var snapshot = {};
+
+  function captureAttr(attr) {
+    // Capture drawing substitutions.
+    if (attr.type === "ELEMENT") {
+      var elementCol = attr.column;
+      if (elementCol) {
+        var elementKeys = elementCol.keyframes;
+        var elementData = [];
+        for (var eki = 0; eki < elementKeys.length; eki++) {
+          elementData.push({ f: elementKeys[eki].frameNumber, v: elementKeys[eki].value });
+        }
+        if (elementData.length > 0) snapshot[attr.keyword] = { __anim: true, keys: elementData, colType: elementCol.type };
+      }
+      return;
+    }
+
+    var subs = attr.subAttributes;
+    if (subs && subs.length > 0) {
+      for (var i = 0; i < subs.length; i++) captureAttr(subs[i]);
+      return;
+    }
+
+    var col = attr.column;
+    if (col) {
+      // Expression columns are driven by the template; don't capture them.
+      if (col.type === "EXPR") return;
+      var keys = col.keyframes;
+      if (keys && keys.length > 0) {
+        var keyData = [];
+        for (var ki = 0; ki < keys.length; ki++) {
+          var v = keys[ki].value;
+          if (v !== null && typeof v === 'object' && typeof v.x === 'number') {
+            v = { x: v.x, y: v.y, z: (typeof v.z === 'number') ? v.z : 0 };
+          }
+          keyData.push({ f: keys[ki].frameNumber, v: v });
+        }
+        if (keyData.length > 0) {
+          snapshot[attr.keyword] = { __anim: true, keys: keyData, colType: col.type };
+          return;
+        }
+      }
+    }
+
+    var val = attr.getValue();
+    if (typeof val === 'string' && val.charAt(0) === '<') return;
+    snapshot[attr.keyword] = val;
+  }
+
+  var attrs = this.attributes;
+  for (var key in attrs) {
+    try { captureAttr(attrs[key]); } catch (e) {}
+  }
+
+  return snapshot;
+};
+
+
+/**
+ * Apply a snapshot produced by getAttributeSnapshot() to this node's attributes.
+ * @param  {object}  snapshot  Object from getAttributeSnapshot().
+ * @return {oNode}   this, for chaining.
+ */
+oNode.prototype.applyAttributeSnapshot = function(snapshot) {
+  for (var keyword in snapshot) {
+    var attr = this.getAttributeByName(keyword);
+    if (!attr) continue;
+
+    var snapVal = snapshot[keyword];
+    var col = attr.column;
+
+    if (attr.type === "ELEMENT") {
+      if (!col) continue;  // no drawing column on the new node, skip
+    } else {
+      if (col && col.type === "EXPR") continue;  // expression-driven, skip
+    }
+
+    if (snapVal && typeof snapVal === 'object' && snapVal.__anim === true) {
+      var keys = snapVal.keys;
+      for (var ki = 0; ki < keys.length; ki++) {
+        attr.setValue(keys[ki].v, keys[ki].f);
+      }
+    } else {
+      attr.setValue(snapVal);
+    }
+  }
+
+  return this;
+};
+
+
  /**
  * Duplicates a node by creating an independent copy.
  * @param   {string}    [newName]              The new name for the duplicated node.

--- a/openHarmony/classes/oNode.js
+++ b/openHarmony/classes/oNode.js
@@ -1639,18 +1639,50 @@ oNode.prototype.clone = function( newName, newPosition ){
 oNode.prototype.getAttributeSnapshot = function() {
   var snapshot = {};
 
+  // Capture per-keyframe interpolation metadata (tangent handles, ease, continuity).
+  // Only BEZIER/EASE columns expose handles; 3DPATH/QUATERNION_PATH delegate to their
+  // velocity curve which itself is BEZIER or EASE.
+  function captureKeyframeEase(frameObject, easeType) {
+    if (easeType !== "BEZIER" && easeType !== "EASE") return null;
+    try {
+      var rawEase = frameObject.ease;
+      if (!rawEase) return null;
+      var capturedEase = {
+        x: rawEase.x,
+        y: rawEase.y,
+        constant: rawEase.constant,
+        continuity: rawEase.continuity
+      };
+      if (easeType === "BEZIER" && rawEase.easeIn && rawEase.easeOut) {
+        capturedEase.easeIn = { x: rawEase.easeIn.x, y: rawEase.easeIn.y };
+        capturedEase.easeOut = { x: rawEase.easeOut.x, y: rawEase.easeOut.y };
+      } else if (easeType === "EASE" && rawEase.easeIn && rawEase.easeOut) {
+        capturedEase.easeIn = {
+          point: rawEase.easeIn.point,
+          angle: rawEase.easeIn.angle
+        };
+        capturedEase.easeOut = {
+          point: rawEase.easeOut.point,
+          angle: rawEase.easeOut.angle
+        };
+      }
+      return capturedEase;
+    } catch (_easeError) {
+      return null;
+    }
+  }
+
   function captureAttr(attr) {
     // --- Drawing substitution column: record each distinct drawing name change ---
     if (attr.type === "ELEMENT") {
       var elementCol = attr.column;
       if (elementCol) {
-        var colName = elementCol.uniqueName;
+        var elementColName = elementCol.uniqueName;
         var sceneLen = $.scene.length;
         var elementData = [];
         var prev = null;
-        // Walk every frame; store only frames where the drawing name changes.
         for (var frame = 1; frame <= sceneLen; frame++) {
-          var drawingName = column.getEntry(colName, 1, frame);
+          var drawingName = column.getEntry(elementColName, 1, frame);
           if (!drawingName) continue;
           if (drawingName !== prev) {
             elementData.push({ f: frame, v: drawingName });
@@ -1667,43 +1699,55 @@ oNode.prototype.getAttributeSnapshot = function() {
     // --- Compound attribute: recurse into sub-attributes ---
     var subs = attr.subAttributes;
     if (subs && subs.length > 0) {
-      for (var i = 0; i < subs.length; i++) captureAttr(subs[i]);
+      for (var subIndex = 0; subIndex < subs.length; subIndex++) captureAttr(subs[subIndex]);
       return;
     }
 
-    // --- Animated column: store each keyframe value ---
+    // --- Animated column: store each keyframe value + ease metadata ---
     var col = attr.column;
     if (col) {
-      // Expression columns are driven by the template; don't capture them.
       if (col.type === "EXPR") return;
-      var keys = col.keyframes;
-      if (keys && keys.length > 0) {
+      var keyframes = col.keyframes;
+      if (keyframes && keyframes.length > 0) {
+        var columnEaseType = col.easeType;
         var keyData = [];
-        for (var keyIndex = 0; keyIndex < keys.length; keyIndex++) {
-          var keyValue = keys[keyIndex].value;
+        for (var keyIndex = 0; keyIndex < keyframes.length; keyIndex++) {
+          var keyframe = keyframes[keyIndex];
+          var keyValue = keyframe.value;
           // Normalise vector values to a plain {x,y,z} object.
           if (keyValue !== null && typeof keyValue === 'object' && typeof keyValue.x === 'number') {
-            keyValue = { x: keyValue.x, y: keyValue.y, z: (typeof keyValue.z === 'number') ? keyValue.z : 0 };
+            keyValue = {
+              x: keyValue.x,
+              y: keyValue.y,
+              z: (typeof keyValue.z === 'number') ? keyValue.z : 0
+            };
           }
-          keyData.push({ f: keys[keyIndex].frameNumber, v: keyValue });
+          var capturedKey = { f: keyframe.frameNumber, v: keyValue };
+          var capturedEase = captureKeyframeEase(keyframe, columnEaseType);
+          if (capturedEase) capturedKey.ease = capturedEase;
+          keyData.push(capturedKey);
         }
         if (keyData.length > 0) {
-          snapshot[attr.keyword] = { __anim: true, keys: keyData, colType: col.type };
+          snapshot[attr.keyword] = {
+            __anim: true,
+            keys: keyData,
+            colType: col.type,
+            easeType: columnEaseType
+          };
           return;
         }
       }
     }
 
     // --- Static value: store as-is, skip XML-blob strings ---
-    var val = attr.getValue();
-    if (typeof val === 'string' && val.charAt(0) === '<') return;
-    snapshot[attr.keyword] = val;
+    var staticValue = attr.getValue();
+    if (typeof staticValue === 'string' && staticValue.charAt(0) === '<') return;
+    snapshot[attr.keyword] = staticValue;
   }
 
-  // Capture every attribute on this node.
   var attrs = this.attributes;
-  for (var key in attrs) {
-    try { captureAttr(attrs[key]); } catch (e) {}
+  for (var attrKey in attrs) {
+    try { captureAttr(attrs[attrKey]); } catch (_attrError) {}
   }
 
   return snapshot;
@@ -1717,6 +1761,51 @@ oNode.prototype.getAttributeSnapshot = function() {
  * @return {oNode}   this, for chaining.
  */
 oNode.prototype.applyAttributeSnapshot = function(snapshot) {
+  function applyEaseAt(columnName, easeType, easeData) {
+    if (!columnName || !easeData) return;
+    try {
+      var continuity = easeData.continuity || "SMOOTH";
+      var isConstant = !!easeData.constant;
+      if (easeType === "BEZIER") {
+        var bezierEaseIn = (easeData.easeIn && typeof easeData.easeIn.x === 'number')
+          ? easeData.easeIn
+          : { x: easeData.x, y: easeData.y };
+        var bezierEaseOut = (easeData.easeOut && typeof easeData.easeOut.x === 'number')
+          ? easeData.easeOut
+          : { x: easeData.x, y: easeData.y };
+        func.setBezierPoint(
+          columnName,
+          easeData.x,
+          easeData.y,
+          bezierEaseIn.x,
+          bezierEaseIn.y,
+          bezierEaseOut.x,
+          bezierEaseOut.y,
+          isConstant,
+          continuity
+        );
+      } else if (easeType === "EASE") {
+        var velocityEaseIn = (easeData.easeIn && typeof easeData.easeIn.point === 'number')
+          ? easeData.easeIn
+          : { point: 0, angle: 0 };
+        var velocityEaseOut = (easeData.easeOut && typeof easeData.easeOut.point === 'number')
+          ? easeData.easeOut
+          : { point: 0, angle: 0 };
+        func.setEasePoint(
+          columnName,
+          easeData.x,
+          easeData.y,
+          velocityEaseIn.point,
+          velocityEaseIn.angle,
+          velocityEaseOut.point,
+          velocityEaseOut.angle,
+          isConstant,
+          continuity
+        );
+      }
+    } catch (_applyEaseError) {}
+  }
+
   for (var keyword in snapshot) {
     try {
       var attr = this.getAttributeByName(keyword);
@@ -1735,9 +1824,9 @@ oNode.prototype.applyAttributeSnapshot = function(snapshot) {
         var keys = snapVal.keys;
         if (attr.type === "ELEMENT") {
           // Drawing exposure: explicitly fill every frame across the whole scene.
-          var colName = col.uniqueName;
+          var elementColName = col.uniqueName;
           var sceneLen = $.scene.length;
-          var snapshotKeyIndex = 0;
+          var elementKeyIndex = 0;
           var setEntryFailed = false;
 
           // If the pasted frame-1 value differs from the snapshot, process frames
@@ -1746,25 +1835,24 @@ oNode.prototype.applyAttributeSnapshot = function(snapshot) {
           var frame1KeyIndex = 0;
           while (frame1KeyIndex + 1 < keys.length && keys[frame1KeyIndex + 1].f <= 1) frame1KeyIndex++;
           var frame1Desired = keys[frame1KeyIndex].v;
-          var deferFrame1 = column.getEntry(colName, 1, 1) !== frame1Desired;
+          var deferFrame1 = column.getEntry(elementColName, 1, 1) !== frame1Desired;
           var frameFillOrder = [];
           for (var fillFrame = (deferFrame1 ? 2 : 1); fillFrame <= sceneLen; fillFrame++) frameFillOrder.push(fillFrame);
           if (deferFrame1) frameFillOrder.push(1); // frame 1 processed last
 
           for (var fillIndex = 0; fillIndex < frameFillOrder.length; fillIndex++) {
             var targetFrame = frameFillOrder[fillIndex];
-            // Advance key pointer to the last snapshot key whose frame <= targetFrame.
-            while (snapshotKeyIndex + 1 < keys.length && keys[snapshotKeyIndex + 1].f <= targetFrame) snapshotKeyIndex++;
+            while (elementKeyIndex + 1 < keys.length && keys[elementKeyIndex + 1].f <= targetFrame) elementKeyIndex++;
             // When retrying frame 1 (processed last), reset to attempt column.setEntry
             // again — the column is no longer freshly-pasted at this point.
             if (deferFrame1 && targetFrame === 1) setEntryFailed = false;
-            var desiredDrawing = keys[snapshotKeyIndex].v;
-            if (column.getEntry(colName, 1, targetFrame) === desiredDrawing) continue;
+            var desiredDrawing = keys[elementKeyIndex].v;
+            if (column.getEntry(elementColName, 1, targetFrame) === desiredDrawing) continue;
             if (!setEntryFailed) {
               try {
-                column.setEntry(colName, 1, targetFrame, desiredDrawing);
+                column.setEntry(elementColName, 1, targetFrame, desiredDrawing);
                 continue;
-              } catch (_fe) {
+              } catch (_setEntryError) {
                 setEntryFailed = true;
               }
             }
@@ -1774,20 +1862,35 @@ oNode.prototype.applyAttributeSnapshot = function(snapshot) {
           // --- Animated non-drawing column.
           // Step 1: Delete every template keyframe that's not in our snapshot, so the
           // column ends up with exactly the keyframes from the original container.
-          // Step 2: Apply our snapshot keys, restoring exactly what was on the old node.
+          // Step 2: Apply our snapshot values.
+          // Step 3: Restore per-keyframe interpolation (handles, ease, continuity).
           var templateKeys = col ? col.keyframes : [];
-          var colName = col ? col.uniqueName : null;
-          var snapFrameSet = {};
-          for (var sk = 0; sk < keys.length; sk++) snapFrameSet[keys[sk].f] = true;
-          if (colName) {
-            for (var tk = 0; tk < templateKeys.length; tk++) {
-              var tf = templateKeys[tk].frameNumber;
-              if (snapFrameSet[tf]) continue;
-              try { column.clearKeyFrame(colName, tf); } catch (_ce) {}
+          var columnName = col ? col.uniqueName : null;
+          var columnEaseType = col ? col.easeType : null;
+          var snapshotFrameSet = {};
+          for (var snapshotKeyIdx = 0; snapshotKeyIdx < keys.length; snapshotKeyIdx++) {
+            snapshotFrameSet[keys[snapshotKeyIdx].f] = true;
+          }
+          if (columnName) {
+            for (var templateKeyIdx = 0; templateKeyIdx < templateKeys.length; templateKeyIdx++) {
+              var templateFrameNumber = templateKeys[templateKeyIdx].frameNumber;
+              if (snapshotFrameSet[templateFrameNumber]) continue;
+              try { column.clearKeyFrame(columnName, templateFrameNumber); } catch (_clearError) {}
             }
           }
-          for (var keyIndex = 0; keyIndex < keys.length; keyIndex++) {
-            attr.setValue(keys[keyIndex].v, keys[keyIndex].f);
+          for (var applyKeyIdx = 0; applyKeyIdx < keys.length; applyKeyIdx++) {
+            var snapshotKey = keys[applyKeyIdx];
+            attr.setValue(snapshotKey.v, snapshotKey.f);
+          }
+          // Second pass for ease: Harmony recomputes handles when neighbouring
+          // keyframes change values, so handles must be applied after all values
+          // are written. Mirrors oColumn.duplicate which sets ease twice for the
+          // same reason.
+          for (var easePassIdx = 0; easePassIdx < keys.length; easePassIdx++) {
+            applyEaseAt(columnName, columnEaseType, keys[easePassIdx].ease);
+          }
+          for (var easeRepeatIdx = 0; easeRepeatIdx < keys.length; easeRepeatIdx++) {
+            applyEaseAt(columnName, columnEaseType, keys[easeRepeatIdx].ease);
           }
         }
       } else {

--- a/openHarmony/classes/oNode.js
+++ b/openHarmony/classes/oNode.js
@@ -1761,6 +1761,11 @@ oNode.prototype.getAttributeSnapshot = function() {
  * @return {oNode}   this, for chaining.
  */
 oNode.prototype.applyAttributeSnapshot = function(snapshot) {
+  // Early-out for nodes that captured no attributes (Multi-Port-In/Out, etc.).
+  var hasAnyKey = false;
+  for (var probeKey in snapshot) { hasAnyKey = true; break; }
+  if (!hasAnyKey) return this;
+
   function applyEaseAt(columnName, easeType, easeData) {
     if (!columnName || !easeData) return;
     try {
@@ -1812,89 +1817,96 @@ oNode.prototype.applyAttributeSnapshot = function(snapshot) {
       if (!attr) continue;
 
       var snapVal = snapshot[keyword];
-      var col = attr.column;
+      var isAnimatedSnapshot = (
+        snapVal && typeof snapVal === 'object' && snapVal.__anim === true
+      );
 
-      if (attr.type === "ELEMENT") {
-        if (!col) continue;  // no drawing column on the new node, skip
-      } else {
-        if (col && col.type === "EXPR") continue;  // expression-driven, skip
+      // Static value fast-path: no native `attr.column` lookup needed.
+      if (!isAnimatedSnapshot) {
+        attr.setValue(snapVal);
+        continue;
       }
 
-      if (snapVal && typeof snapVal === 'object' && snapVal.__anim === true) {
-        var keys = snapVal.keys;
-        if (attr.type === "ELEMENT") {
-          // Drawing exposure: explicitly fill every frame across the whole scene.
-          var elementColName = col.uniqueName;
-          var sceneLen = $.scene.length;
-          var elementKeyIndex = 0;
-          var setEntryFailed = false;
+      var col = attr.column;
+      if (attr.type === "ELEMENT") {
+        if (!col) continue;  // no drawing column on the new node
+      } else if (col && col.type === "EXPR") {
+        continue;  // expression-driven, leave the template's expression alone
+      }
 
-          // If the pasted frame-1 value differs from the snapshot, process frames
-          // 2+ first so frame-1 is not overwritten while later frames are still
-          // "held" from it.
-          var frame1KeyIndex = 0;
-          while (frame1KeyIndex + 1 < keys.length && keys[frame1KeyIndex + 1].f <= 1) frame1KeyIndex++;
-          var frame1Desired = keys[frame1KeyIndex].v;
-          var deferFrame1 = column.getEntry(elementColName, 1, 1) !== frame1Desired;
-          var frameFillOrder = [];
-          for (var fillFrame = (deferFrame1 ? 2 : 1); fillFrame <= sceneLen; fillFrame++) frameFillOrder.push(fillFrame);
-          if (deferFrame1) frameFillOrder.push(1); // frame 1 processed last
+      var keys = snapVal.keys;
+      if (attr.type === "ELEMENT") {
+        // Drawing exposure: explicitly fill every frame across the whole scene.
+        var elementColName = col.uniqueName;
+        var sceneLen = $.scene.length;
+        var elementKeyIndex = 0;
+        var setEntryFailed = false;
 
-          for (var fillIndex = 0; fillIndex < frameFillOrder.length; fillIndex++) {
-            var targetFrame = frameFillOrder[fillIndex];
-            while (elementKeyIndex + 1 < keys.length && keys[elementKeyIndex + 1].f <= targetFrame) elementKeyIndex++;
-            // When retrying frame 1 (processed last), reset to attempt column.setEntry
-            // again — the column is no longer freshly-pasted at this point.
-            if (deferFrame1 && targetFrame === 1) setEntryFailed = false;
-            var desiredDrawing = keys[elementKeyIndex].v;
-            if (column.getEntry(elementColName, 1, targetFrame) === desiredDrawing) continue;
-            if (!setEntryFailed) {
-              try {
-                column.setEntry(elementColName, 1, targetFrame, desiredDrawing);
-                continue;
-              } catch (_setEntryError) {
-                setEntryFailed = true;
-              }
-            }
-            node.setTextAttr(this.path, "drawing.element", targetFrame, desiredDrawing);
-          }
-        } else {
-          // --- Animated non-drawing column.
-          // Step 1: Delete every template keyframe that's not in our snapshot, so the
-          // column ends up with exactly the keyframes from the original container.
-          // Step 2: Apply our snapshot values.
-          // Step 3: Restore per-keyframe interpolation (handles, ease, continuity).
-          var templateKeys = col ? col.keyframes : [];
-          var columnName = col ? col.uniqueName : null;
-          var columnEaseType = col ? col.easeType : null;
-          var snapshotFrameSet = {};
-          for (var snapshotKeyIdx = 0; snapshotKeyIdx < keys.length; snapshotKeyIdx++) {
-            snapshotFrameSet[keys[snapshotKeyIdx].f] = true;
-          }
-          if (columnName) {
-            for (var templateKeyIdx = 0; templateKeyIdx < templateKeys.length; templateKeyIdx++) {
-              var templateFrameNumber = templateKeys[templateKeyIdx].frameNumber;
-              if (snapshotFrameSet[templateFrameNumber]) continue;
-              try { column.clearKeyFrame(columnName, templateFrameNumber); } catch (_clearError) {}
+        // If the pasted frame-1 value differs from the snapshot, process frames
+        // 2+ first so frame-1 is not overwritten while later frames are still
+        // "held" from it.
+        var frame1KeyIndex = 0;
+        while (frame1KeyIndex + 1 < keys.length && keys[frame1KeyIndex + 1].f <= 1) frame1KeyIndex++;
+        var frame1Desired = keys[frame1KeyIndex].v;
+        var deferFrame1 = column.getEntry(elementColName, 1, 1) !== frame1Desired;
+        var frameFillOrder = [];
+        for (var fillFrame = (deferFrame1 ? 2 : 1); fillFrame <= sceneLen; fillFrame++) frameFillOrder.push(fillFrame);
+        if (deferFrame1) frameFillOrder.push(1); // frame 1 processed last
+
+        for (var fillIndex = 0; fillIndex < frameFillOrder.length; fillIndex++) {
+          var targetFrame = frameFillOrder[fillIndex];
+          while (elementKeyIndex + 1 < keys.length && keys[elementKeyIndex + 1].f <= targetFrame) elementKeyIndex++;
+          // When retrying frame 1 (processed last), reset to attempt column.setEntry
+          // again — the column is no longer freshly-pasted at this point.
+          if (deferFrame1 && targetFrame === 1) setEntryFailed = false;
+          var desiredDrawing = keys[elementKeyIndex].v;
+          if (column.getEntry(elementColName, 1, targetFrame) === desiredDrawing) continue;
+          if (!setEntryFailed) {
+            try {
+              column.setEntry(elementColName, 1, targetFrame, desiredDrawing);
+              continue;
+            } catch (_setEntryError) {
+              setEntryFailed = true;
             }
           }
-          for (var applyKeyIdx = 0; applyKeyIdx < keys.length; applyKeyIdx++) {
-            var snapshotKey = keys[applyKeyIdx];
-            attr.setValue(snapshotKey.v, snapshotKey.f);
-          }
-          // Second pass for ease: Harmony recomputes handles when neighbouring
-          // keyframes change values, so handles must be applied after all values
-          // are written. Mirrors oColumn.duplicate which sets ease twice for the
-          // same reason.
-          for (var easePassIdx = 0; easePassIdx < keys.length; easePassIdx++) {
-            applyEaseAt(columnName, columnEaseType, keys[easePassIdx].ease);
-          }
-          for (var easeRepeatIdx = 0; easeRepeatIdx < keys.length; easeRepeatIdx++) {
-            applyEaseAt(columnName, columnEaseType, keys[easeRepeatIdx].ease);
-          }
+          node.setTextAttr(this.path, "drawing.element", targetFrame, desiredDrawing);
         }
-      } else {
-        attr.setValue(snapVal);
+        continue;
+      }
+
+      // --- Animated non-drawing column.
+      // Step 1: Delete every template keyframe that's not in our snapshot.
+      // Step 2: Apply our snapshot values.
+      // Step 3: Restore per-keyframe interpolation (handles, ease, continuity).
+      var columnName = col ? col.uniqueName : null;
+      var columnEaseType = col ? col.easeType : null;
+      var snapshotFrameSet = {};
+      for (var snapshotKeyIdx = 0; snapshotKeyIdx < keys.length; snapshotKeyIdx++) {
+        snapshotFrameSet[keys[snapshotKeyIdx].f] = true;
+      }
+      // Enumerate template keyframes by raw point index — avoids allocating an
+      // oFrame for every frame of the scene via `col.keyframes` / `col.frames`.
+      if (columnName) {
+        var numTemplatePoints = 0;
+        try { numTemplatePoints = func.numberOfPoints(columnName); } catch (_npe) {}
+        for (var templatePointIdx = 0; templatePointIdx < numTemplatePoints; templatePointIdx++) {
+          var templateFrameNumber = func.pointX(columnName, templatePointIdx);
+          if (snapshotFrameSet[templateFrameNumber]) continue;
+          try { column.clearKeyFrame(columnName, templateFrameNumber); } catch (_clearError) {}
+        }
+      }
+      for (var applyKeyIdx = 0; applyKeyIdx < keys.length; applyKeyIdx++) {
+        var snapshotKey = keys[applyKeyIdx];
+        attr.setValue(snapshotKey.v, snapshotKey.f);
+      }
+      // Two ease passes: Harmony adjusts neighbour handles when a keyframe is
+      // written, so the first pass can corrupt earlier writes; pass two locks
+      // them in. Same pattern as oColumn.duplicate.
+      for (var easePassIdx = 0; easePassIdx < keys.length; easePassIdx++) {
+        applyEaseAt(columnName, columnEaseType, keys[easePassIdx].ease);
+      }
+      for (var easeRepeatIdx = 0; easeRepeatIdx < keys.length; easeRepeatIdx++) {
+        applyEaseAt(columnName, columnEaseType, keys[easeRepeatIdx].ease);
       }
     } catch (err) {
       this.$.log(

--- a/openHarmony/classes/oNode.js
+++ b/openHarmony/classes/oNode.js
@@ -1918,6 +1918,15 @@ oNode.prototype.applyAttributeSnapshot = function(snapshot) {
         var snapshotKey = keys[applyKeyIdx];
         attr.setValue(snapshotKey.v, snapshotKey.f);
       }
+
+      if (!col) {
+        col = attr.column;
+        if (col) {
+          columnName = col.uniqueName;
+          columnEaseType = col.easeType;
+        }
+      }
+
       // Two ease passes: Harmony adjusts neighbour handles when a keyframe is
       // written, so the first pass can corrupt earlier writes; pass two locks
       // them in. Same pattern as oColumn.duplicate.

--- a/openHarmony/tests/oNode.js
+++ b/openHarmony/tests/oNode.js
@@ -206,5 +206,73 @@ exports.testoNodeShorthandDifferentTypes = {
     },
 }
 
+/**
+ * Tests for oNode.getAttributeSnapshot / applyAttributeSnapshot
+ * Verifies: oNode.getAttributeSnapshot captures and applies attribute values, including animation keyframes and drawing substitutions.
+ */
+exports.testSnapshotRoundtrip = {
+    message: "oNode snapshot roundtrip preserves static attribute values",
+    prepare: function() {},
+    run: function() {
+        var peg = $.scn.root.addNode('PEG');
+        peg.attributes.position.x.setValue(123);
+        peg.attributes.position.y.setValue(456);
+
+        var snap = peg.getAttributeSnapshot();
+
+        peg.attributes.position.x.setValue(0);
+        peg.attributes.position.y.setValue(0);
+
+        peg.applyAttributeSnapshot(snap);
+
+        assert(peg.attributes.position.x.getValue(), 123, 'position.x should be restored');
+        assert(peg.attributes.position.y.getValue(), 456, 'position.y should be restored');
+    },
+    check: function() {},
+};
+
+exports.testSnapshotAnimated = {
+    message: "oNode snapshot roundtrip preserves keyframe data",
+    prepare: function() {},
+    run: function() {
+        var peg = $.scn.root.addNode('PEG');
+        var attr = peg.attributes.position.x;
+        attr.setValue(10, 1);
+        attr.setValue(20, 5);
+        attr.setValue(30, 10);
+
+        var snap = peg.getAttributeSnapshot();
+
+        attr.setValue(0, 1);
+        attr.setValue(0, 5);
+        attr.setValue(0, 10);
+
+        peg.applyAttributeSnapshot(snap);
+
+        assert(attr.getValue(1),  10, 'keyframe at f1 should be restored');
+        assert(attr.getValue(5),  20, 'keyframe at f5 should be restored');
+        assert(attr.getValue(10), 30, 'keyframe at f10 should be restored');
+    },
+    check: function() {},
+};
+
+exports.testSnapshotDrawingSubstitution = {
+    message: "oNode snapshot roundtrip preserves drawing substitutions on READ nodes",
+    prepare: function() {},
+    run: function() {
+        var read = $.scn.root.addNode('READ');
+        var drawingAttr = read.attributes.drawing;
+
+        // Only meaningful if the node has a drawing column (element attached)
+        if (!drawingAttr || !drawingAttr.column) return;
+
+        var snap = read.getAttributeSnapshot();
+        assert(typeof snap === 'object', true, 'snapshot should be an object');
+
+        // Reapply should not throw
+        read.applyAttributeSnapshot(snap);
+    },
+    check: function() {},
+};
 
 // ---------


### PR DESCRIPTION
In pipeline workflows, you often need to update a template with a newer one but keep any alterations made by the artist to the rig/nodetree. This feature allows to save a snapshot of a node before removing it, and applying the snapshot to a similar node. It could be used in loops to preserve a whole node tree values.