### PR TITLE
Remove typo var

### DIFF
--- a/openHarmony/classes/oNode.js
+++ b/openHarmony/classes/oNode.js
@@ -1579,7 +1579,7 @@ oNode.prototype.orderAboveNodes = function(verticalSpacing, horizontalSpacing){
 
   // sort orphaned nodes by placing them on an inbetween level
   for (var i in failedUpSort){
-    var sortNode = failedUpSort[i];s
+    var sortNode = failedUpSort[i];
     sortNode.centerBelow(sortNode.linkedInNodes, 0, verticalSpacing/2);
   }
 


### PR DESCRIPTION
Noticed this typo var which fails silently because unreached in most of cases.

The change of the end of the file is from github IDE itself, can't do any thing about it I'm afraid.